### PR TITLE
chore: disable telemetry in our private network

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ The Ziggurat implementation for Algorand's `algod` nodes.
 2. Build [go-algorand](https://github.com/algorand/go-algorand) from source.
 3. Run the setup script:
 ```zsh
-    ./tools/setup_env.sh
+    tools/setup_env.sh
 ```
 
 In case algorand files are installed in a specific location, export that location to the `ALGORAND_BIN_PATH`
 environment variable and rerun the setup script:
 ```zsh
     export ALGORAND_BIN_PATH="$HOME/node/"   # example path
-    ./tools/setup_env.sh
+    tools/setup_env.sh
 ```
 4. Run tests with the following command:
 ```zsh

--- a/tools/logging.config
+++ b/tools/logging.config
@@ -1,0 +1,1 @@
+{"Enable":false,"SendToLog":false,"URI":"","Name":"Primary","GUID":"","FilePath":"","UserName":"","Password":"","MinLogLevel":3,"ReportHistoryLevel":3}

--- a/tools/setup_env.sh
+++ b/tools/setup_env.sh
@@ -2,7 +2,10 @@
 # This script sets up the environment for the Ziggurat test suite.
 #
 # The private network setup is explained here:
-#      https://developer.algorand.org/docs/clis/goal/network/create/
+# [1] https://developer.algorand.org/docs/clis/goal/network/create/
+
+# Telemetry config settings are explained here:
+# [2] https://developer.algorand.org/docs/run-a-node/reference/telemetry-config/
 
 set -e
 
@@ -24,7 +27,7 @@ ZIGGURAT_ALGORAND_PN_DIR="$ZIGGURAT_ALGORAND_DIR/private_network"
 setup_config_file() {
     echo "--- Setting up configuration file"
     echo "Creating $ZIGGURAT_ALGORAND_SETUP_CFG_FILE with contents:"
-    mkdir $ZIGGURAT_ALGORAND_SETUP_DIR
+    mkdir -p $ZIGGURAT_ALGORAND_SETUP_DIR
     echo
     echo "# Algorand installation path" > $ZIGGURAT_ALGORAND_SETUP_CFG_FILE
     echo "path = \"$ALGORAND_BIN_PATH\"" >> $ZIGGURAT_ALGORAND_SETUP_CFG_FILE
@@ -38,8 +41,12 @@ setup_config_file() {
 
 setup_private_network() {
     echo "--- Setting up private network files at the location $ZIGGURAT_ALGORAND_PN_DIR"
-    $GOAL_CMD network create -r $ZIGGURAT_ALGORAND_PN_DIR -n private -t tools/ziggurat_network_template.json
+    $GOAL_CMD network create -r $ZIGGURAT_ALGORAND_PN_DIR -n private -t tools/ziggurat_network_template.json # see [1]
     echo
+
+    # Copy telemetry config file manually to ensure nodes don't look for the global config file at ~/.algorand/
+    cp tools/logging.config $ZIGGURAT_ALGORAND_PN_DIR/Node0/  # see [2]
+    cp tools/logging.config $ZIGGURAT_ALGORAND_PN_DIR/Node1/  # see [2]
 }
 
 # Verify the algod binary path using the version option

--- a/tools/ziggurat_network_template.json
+++ b/tools/ziggurat_network_template.json
@@ -3,17 +3,17 @@
         "NetworkName": "ZigguratNet",
         "Wallets": [
             {
-                "Name": "Wallet1",
+                "Name": "Wallet0",
                 "Stake": 80,
                 "Online": true
             },
             {
-                "Name": "Wallet2",
+                "Name": "Wallet1",
                 "Stake": 5,
                 "Online": true
             },
             {
-                "Name": "Wallet3",
+                "Name": "Wallet2",
                 "Stake": 15,
                 "Online": false
             }
@@ -21,24 +21,24 @@
     },
     "Nodes": [
         {
-            "Name": "Node1",
+            "Name": "Node0",
             "IsRelay": true,
             "Wallets": [
                 {
-                    "Name": "Wallet1",
+                    "Name": "Wallet0",
                     "ParticipationOnly": false
                 }
             ]
         },
         {
-            "Name": "Node2",
+            "Name": "Node1",
             "Wallets": [
                 {
-                    "Name": "Wallet2",
+                    "Name": "Wallet1",
                     "ParticipationOnly": false
                 },
                 {
-                    "Name": "Wallet3",
+                    "Name": "Wallet2",
                     "ParticipationOnly": false
                 }
             ]


### PR DESCRIPTION
- Nodes shouldn't try to access anything outside of their temp folders, so copy the logging.config to private network directories
- Small readme update
- Index private network nodes and wallets to start from zero