### PR TITLE
feat: add node implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,16 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0"
+fs_extra = "1.2"
+home = "0.5.3"
+tempfile = "3.3"
+toml = "0.5.9"
+
+[dependencies.serde]
+version = "1"
+features = [ "derive" ]
+
+[dependencies.tokio]
+version = "1"
+features = [ "full" ]

--- a/src/setup/config.rs
+++ b/src/setup/config.rs
@@ -1,0 +1,65 @@
+//! Utilities for node configuration.
+
+use std::{
+    ffi::OsString,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::Result;
+use serde::Deserialize;
+
+use crate::setup::constants::SETUP_CONFIG;
+
+/// Startup configuration for the node.
+#[derive(Debug, Clone, Default)]
+pub struct NodeConfig {
+    /// Setting this option to true will enable node logging to stdout.
+    pub log_to_stdout: bool,
+    /// The path of the cache directory of the node.
+    pub path: PathBuf,
+}
+
+/// Convenience struct for reading Ziggurat's configuration file.
+#[derive(Deserialize)]
+struct ConfigFile {
+    /// The absolute path of where to run the start command.
+    path: PathBuf,
+    /// The command to start the node.
+    start_command: String,
+}
+
+/// The node metadata read from Ziggurat's configuration file.
+#[derive(Debug, Clone)]
+pub struct NodeMetaData {
+    /// The absolute path of where to run the start command.
+    pub path: PathBuf,
+    /// The command to start the node.
+    pub start_command: OsString,
+    /// The arguments to the start command of the node.
+    pub start_args: Vec<OsString>,
+}
+
+impl NodeMetaData {
+    pub fn new(setup_path: &Path) -> Result<NodeMetaData> {
+        // Read Ziggurat's configuration file.
+        let path = setup_path.join(SETUP_CONFIG);
+        let config_string = fs::read_to_string(path)?;
+        let config_file: ConfigFile = toml::from_str(&config_string)?;
+
+        // Read the args (which includes the start command at index 0).
+        let args_from = |command: &str| -> Vec<OsString> {
+            command.split_whitespace().map(OsString::from).collect()
+        };
+
+        // Separate the start command from the args list.
+        let mut start_args = args_from(&config_file.start_command);
+        let start_command = start_args.remove(0);
+
+        Ok(Self {
+            path: config_file.path,
+            start_command,
+            start_args,
+        })
+    }
+}

--- a/src/setup/constants.rs
+++ b/src/setup/constants.rs
@@ -1,0 +1,19 @@
+//! Useful setup constants.
+
+/// Ziggurat's configuration directory.
+pub const ZIGGURAT_DIR: &str = ".ziggurat";
+
+/// Ziggurat's Algorand's subdir.
+pub const ALGORAND_WORK_DIR: &str = "algorand";
+
+/// Initial setup dir for algod.
+pub const ALGORAND_SETUP_DIR: &str = "setup";
+
+/// Configuration file with paths to start algod.
+pub const SETUP_CONFIG: &str = "config.toml";
+
+/// Directory for the preloaded network of nodes which contain saved ledger and configuration data.
+pub const PRIVATE_NETWORK_DIR: &str = "private_network";
+
+/// Node directory without an index. The correctly indexed node directory is "Node0".
+pub const NODE_DIR: &str = "Node";

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -1,1 +1,18 @@
-//! Utilities for setting up and tearing down node Algorand node instances.
+//! Utilities for setting up and tearing down Algorand node instances.
+
+pub mod config;
+pub mod constants;
+#[allow(dead_code)]
+pub mod node;
+
+use std::{io, path::PathBuf};
+
+use crate::setup::constants::{ALGORAND_WORK_DIR, ZIGGURAT_DIR};
+
+/// Construct Ziggurat's work path for Algorand
+pub fn get_algorand_work_path() -> io::Result<PathBuf> {
+    Ok(home::home_dir()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "Couldn't find the home directory"))?
+        .join(ZIGGURAT_DIR)
+        .join(ALGORAND_WORK_DIR))
+}

--- a/src/setup/node.rs
+++ b/src/setup/node.rs
@@ -1,0 +1,186 @@
+//! High level APIs and types for node setup and teardown.
+
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
+};
+
+use anyhow::Result;
+use fs_extra::dir;
+
+use super::constants::{ALGORAND_SETUP_DIR, NODE_DIR, PRIVATE_NETWORK_DIR};
+use crate::setup::{
+    config::{NodeConfig, NodeMetaData},
+    get_algorand_work_path,
+};
+
+pub enum ChildExitCode {
+    Success,
+    ErrorCode(Option<i32>),
+}
+
+pub struct NodeBuilder {
+    /// Node's startup configuration.
+    conf: NodeConfig,
+    /// Node's process metadata read from Ziggurat configuration files.
+    meta: NodeMetaData,
+}
+
+impl NodeBuilder {
+    /// Creates a new [NodeBuilder].
+    pub fn new() -> anyhow::Result<Self> {
+        let setup_path = get_algorand_work_path()?.join(ALGORAND_SETUP_DIR);
+
+        let conf = NodeConfig::default();
+        let meta = NodeMetaData::new(&setup_path)?;
+
+        Ok(Self { conf, meta })
+    }
+
+    /// Creates a [Node] according to configuration.
+    pub fn build(&self, target: &Path) -> Result<Node> {
+        if !target.exists() {
+            fs::create_dir_all(target)?;
+        }
+
+        // Currently we can start only the first node.
+        let source = Node::get_path(0)?;
+
+        let mut copy_options = dir::CopyOptions::new();
+        copy_options.content_only = true;
+        copy_options.overwrite = true;
+        dir::copy(&source, target, &copy_options)?;
+
+        // TODO(Rqnsom) configure the node.
+
+        let mut conf = self.conf.clone();
+        conf.path = target.to_path_buf();
+
+        Ok(Node {
+            child: None,
+            conf,
+            meta: self.meta.clone(),
+        })
+    }
+
+    /// Sets whether to log the node's output to Ziggurat's output stream.
+    pub fn log_to_stdout(mut self, log_to_stdout: bool) -> Self {
+        self.conf.log_to_stdout = log_to_stdout;
+        self
+    }
+}
+
+pub struct Node {
+    /// Node's process.
+    child: Option<Child>,
+    /// Node's startup configuration.
+    conf: NodeConfig,
+    /// Node's process metadata read from Ziggurat configuration files.
+    meta: NodeMetaData,
+}
+
+impl Node {
+    /// Creates a NodeBuilder.
+    pub fn builder() -> NodeBuilder {
+        NodeBuilder::new()
+            .map_err(|e| format!("Unable to create a builder: {:?}", e))
+            .unwrap()
+    }
+
+    /// Starts the node instance.
+    pub fn start(&mut self) {
+        let (stdout, stderr) = match self.conf.log_to_stdout {
+            true => (Stdio::inherit(), Stdio::inherit()),
+            false => (Stdio::null(), Stdio::null()),
+        };
+
+        // Specify node's data path location with the `-d` option.
+        self.meta.start_args.push("-d".into());
+        self.meta.start_args.push(self.conf.path.clone().into());
+
+        if self.conf.log_to_stdout {
+            // Write to stdout instead of node.log using the option '-o'.
+            self.meta.start_args.push("-o".into());
+        }
+
+        let child = Command::new(&self.meta.start_command)
+            .current_dir(&self.meta.path)
+            .args(&self.meta.start_args)
+            .stdin(Stdio::null())
+            .stdout(stdout)
+            .stderr(stderr)
+            .spawn()
+            .expect("Node failed to start");
+        self.child = Some(child);
+
+        // TODO(Rqnsom) wait for the connection to confirm.
+    }
+
+    /// Stops the node instance.
+    pub fn stop(&mut self) -> io::Result<ChildExitCode> {
+        // Cannot use 'mut self' due to the Drop impl.
+
+        let child = match self.child {
+            Some(ref mut child) => child,
+            None => return Ok(ChildExitCode::Success),
+        };
+
+        match child.try_wait()? {
+            None => child.kill()?,
+            Some(code) => return Ok(ChildExitCode::ErrorCode(code.code())),
+        }
+        let exit = child.wait()?;
+
+        match exit.code() {
+            None => Ok(ChildExitCode::Success),
+            Some(exit) if exit == 0 => Ok(ChildExitCode::Success),
+            Some(exit) => Ok(ChildExitCode::ErrorCode(Some(exit))),
+        }
+    }
+
+    fn get_path(node_dir_idx: usize) -> io::Result<PathBuf> {
+        Ok(get_algorand_work_path()?
+            .join(PRIVATE_NETWORK_DIR)
+            .join(format!("{NODE_DIR}{node_dir_idx}")))
+    }
+}
+
+impl Drop for Node {
+    fn drop(&mut self) {
+        // We should avoid a panic.
+        if let Err(e) = self.stop() {
+            eprintln!("Failed to stop the node: {}", e);
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use tempfile::TempDir;
+    use tokio::time::{sleep, Duration};
+
+    use super::*;
+
+    const SLEEP: Duration = Duration::from_millis(500);
+
+    #[tokio::test]
+    async fn start_stop_the_node() {
+        let builder = Node::builder();
+        let target = TempDir::new().expect("Couldn't create a temporary directory");
+
+        let mut node = builder
+            .log_to_stdout(true)
+            .build(target.path())
+            .expect("Unable to build the node");
+
+        node.start();
+        sleep(SLEEP).await;
+        assert!(node.stop().is_ok());
+
+        // Restart the node.
+        node.start();
+        sleep(SLEEP).await;
+        // The node will be stopped via the Drop impl.
+    }
+}


### PR DESCRIPTION
- Added NodeBuilder implementation:
  - Reads NodeMetaData from "~/.ziggurat/algorand/setup/config.toml".
  - Can spawn one node (at the moment) using the preconfigured node stored at "~/.ziggurat/algorand/private_network/Node0".
  - Can configure logging.

- Added Node implementation:
  - Can be stopped (killed).

- Tests:
  - A simple 'start/stop' node test is included. Will be deprecated later.