### PR TITLE
feat: verify the node is running after startup

### DIFF
--- a/src/setup/config.rs
+++ b/src/setup/config.rs
@@ -52,14 +52,14 @@ impl NodeConfig {
 
     /// Fetches the node's addresses.
     pub async fn load_addrs(&mut self) -> Result<()> {
-        let mut local_addr = String::new();
+        let mut net_addr = String::new();
         let mut rest_addr = String::new();
 
         timeout(LOAD_ADDR_TIMEOUT_SECS, async {
-            let local_addr_path = self.path.join(NET_ADDR_FILE);
+            let net_addr_path = self.path.join(NET_ADDR_FILE);
             let rest_addr_path = self.path.join(REST_ADDR_FILE);
 
-            local_addr = NodeConfig::try_read_to_string(&local_addr_path).await;
+            net_addr = NodeConfig::try_read_to_string(&net_addr_path).await;
             rest_addr = NodeConfig::try_read_to_string(&rest_addr_path).await;
         })
         .await
@@ -67,7 +67,7 @@ impl NodeConfig {
 
         self.net_addr = Some(
             SocketAddr::from_str(
-                local_addr
+                net_addr
                     .trim()
                     .strip_prefix("http://")
                     .expect("The http prefix is missing."),

--- a/src/setup/constants.rs
+++ b/src/setup/constants.rs
@@ -35,3 +35,6 @@ pub const REST_ADDR_FILE: &str = "algod.net";
 
 /// Timeout when waiting for loading of addresses.
 pub const LOAD_ADDR_TIMEOUT_SECS: Duration = Duration::from_secs(1);
+
+/// Timeout when waiting for [Node](crate::setup::node::Node)'s start.
+pub const CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);


### PR DESCRIPTION
- The node's network address should be listening for incoming connections if the node has started properly.
- Variable correctly renamed in `config.rs`