### PR TITLE
feat: c003 get block

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,32 +3,34 @@ name = "ziggurat-algorand"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 anyhow = "1.0"
-fs_extra = "1.2"
-home = "0.5.3"
-tempfile = "3.3"
-toml = "0.5.9"
 async-trait = "0.1"
-bytes = "1"
-futures-util = { version = "0.3", features = ["sink"] }
-httparse = "1.8"
-tungstenite = "0.17"
-tokio-tungstenite = "0.17"
-websocket-codec = "0.5"
-tokio-util = { version = "0.7", features = ["codec"] }
-pea2pea = "0.40"
 base64 = "0.13"
+bytes = "1"
+data-encoding = "2.3"
+fs_extra = "1.2"
+futures-util = { version = "0.3", features = ["sink"] }
+home = "0.5.3"
+httparse = "1.8"
+pea2pea = "0.40"
+radix_fmt = "1.0"
+reqwest = { version = "0.11" }
+rmp-serde = "1.0.0"
+tempfile = "3.3"
+tokio-tungstenite = "0.17"
+tokio-util = { version = "0.7", features = ["codec"] }
+toml = "0.5.9"
+tungstenite = "0.17"
+websocket-codec = "0.5"
 
 [dependencies.serde]
 version = "1"
-features = [ "derive" ]
+features = ["derive"]
 
 [dependencies.tokio]
 version = "1"
-features = [ "full" ]
+features = ["full"]
 
 [dependencies.tracing]
 version = "0.1"

--- a/SPEC.md
+++ b/SPEC.md
@@ -91,3 +91,13 @@ The test index makes use of symbolic language in describing connection and messa
 
     Assert: the node’s peer count has increased to 1 and the synthetic node is an established peer.
 
+### ZG-CONFORMANCE-003
+
+    The node responds correctly to a block request message (V1 algod API) which is how newly connected node queries for block data.
+
+    <>
+    -> http GET /v1/block/{round}
+    <- http response with block-certificate data
+
+    Assert: the appropriate response is sent.
+

--- a/src/protocol/constants.rs
+++ b/src/protocol/constants.rs
@@ -1,0 +1,4 @@
+//! Useful protocol constants.
+
+/// User agent.
+pub const USER_AGENT: &str = "algod/3.9 (stable; commit=921e8f6f+; 0) linux(amd64)";

--- a/src/protocol/handshake.rs
+++ b/src/protocol/handshake.rs
@@ -6,9 +6,8 @@ use pea2pea::{protocols::Handshake, Connection, ConnectionSide, Pea2Pea};
 use tokio_util::codec::{BytesCodec, Framed};
 use tracing::*;
 
-use crate::tools::inner_node::InnerNode;
+use crate::{protocol::constants::USER_AGENT, tools::inner_node::InnerNode};
 
-const USER_AGENT: &str = "algod/3.9 (stable; commit=921e8f6f+; 0) linux(amd64)";
 const SEC_WEBSOCKET_VERSION: &str = "13";
 const X_AG_ACCEPT_VERSION: &str = "2.1";
 const X_AG_INSTANCE_NAME: &str = "synth_node"; // Can be shared between different synthetic nodes

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,6 +1,7 @@
 //! An implementation of the Algorand network protocol types and messages.
 
 pub mod codecs;
+pub mod constants;
 mod handshake;
 mod reading;
 mod writing;

--- a/src/tests/conformance/mod.rs
+++ b/src/tests/conformance/mod.rs
@@ -1,1 +1,2 @@
 mod handshake;
+mod post_handshake;

--- a/src/tests/conformance/post_handshake/mod.rs
+++ b/src/tests/conformance/post_handshake/mod.rs
@@ -1,0 +1,1 @@
+mod query;

--- a/src/tests/conformance/post_handshake/query/get_block.rs
+++ b/src/tests/conformance/post_handshake/query/get_block.rs
@@ -1,0 +1,71 @@
+use tempfile::TempDir;
+
+use crate::{
+    setup::node::Node,
+    tools::{rpc, synthetic_node::SyntheticNodeBuilder},
+};
+
+#[tokio::test]
+#[allow(non_snake_case)]
+async fn c003_V1_BLOCK_ROUND_get_block() {
+    // ZG-CONFORMANCE-003
+
+    // Spin up a node instance.
+    let target = TempDir::new().expect("Couldn't create a temporary directory");
+    let mut node = Node::builder()
+        .build(target.path())
+        .expect("Unable to build the node");
+    node.start().await;
+
+    // Create a synthetic node and enable handshaking.
+    let synthetic_node = SyntheticNodeBuilder::default()
+        .build()
+        .await
+        .expect("Unable to build a synthetic node");
+
+    let net_addr = node.net_addr().expect("Network address not found");
+
+    // Connect to the node and initiate the handshake.
+    synthetic_node
+        .connect(net_addr)
+        .await
+        .expect("Unable to connect");
+
+    let rpc_addr = net_addr.to_string();
+
+    // Get block for the round 0.
+    let round = 0;
+    let block_cert = rpc::wait_for_block(&rpc_addr, round)
+        .await
+        .expect("Couldn't get a block");
+    assert_eq!(round, block_cert.block.round, "Invalid round");
+    assert!(block_cert.block.sortition_seed.is_some(), "Seed not found");
+    assert!(
+        block_cert.block.genesis_id_hash.is_some(),
+        "Genesis hash not found"
+    );
+    assert!(
+        block_cert.block.prevous_block_hash.is_none(),
+        "Previous block hash shouldn't be found for the first block"
+    );
+
+    // Get block for the round 1.
+    let round = 1;
+    let block_cert = rpc::wait_for_block(&rpc_addr, round)
+        .await
+        .expect("Couldn't get a block");
+    assert_eq!(round, block_cert.block.round, "Invalid round");
+    assert!(block_cert.block.sortition_seed.is_some(), "Seed not found");
+    assert!(
+        block_cert.block.genesis_id_hash.is_some(),
+        "Genesis hash not found"
+    );
+    assert!(
+        block_cert.block.prevous_block_hash.is_some(),
+        "Previous block hash not found"
+    );
+
+    // Gracefully shut down the nodes.
+    synthetic_node.shut_down().await;
+    node.stop().expect("Unable to stop the node");
+}

--- a/src/tests/conformance/post_handshake/query/mod.rs
+++ b/src/tests/conformance/post_handshake/query/mod.rs
@@ -1,0 +1,1 @@
+mod get_block;

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -4,4 +4,6 @@
 pub mod constants;
 pub mod inner_node;
 #[allow(dead_code)]
+pub mod rpc;
+#[allow(dead_code)]
 pub mod synthetic_node;

--- a/src/tools/rpc.rs
+++ b/src/tools/rpc.rs
@@ -1,0 +1,238 @@
+use std::{
+    fmt::{self, Display, Formatter},
+    time::Duration,
+};
+
+use data_encoding::{BASE32_NOPAD, BASE64};
+use fmt::Debug;
+use reqwest::{header, Client};
+use serde::{
+    de::{Error, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+use tokio::time::{error::Elapsed, sleep};
+
+use crate::protocol::constants::USER_AGENT;
+
+/// Timeout time for RPC requests.
+const RPC_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Default)]
+struct HttpClient {
+    client: Client,
+}
+
+impl HttpClient {
+    async fn get_block(
+        &self,
+        rpc_addr: &str,
+        round: &str,
+    ) -> anyhow::Result<reqwest::Response, reqwest::Error> {
+        // Replica of the HTTP request our synth node receives from the node.
+        self.client
+            .get(format!("http://{}/v1/private-v1/block/{}", rpc_addr, round))
+            .header(header::HOST, rpc_addr)
+            .header(header::USER_AGENT, USER_AGENT)
+            .header(header::ACCEPT_ENCODING, "gzip")
+            .send()
+            .await
+    }
+}
+
+/// Returns a block for a provided round.
+pub async fn wait_for_block(rpc_addr: &str, round: u64) -> Result<EncodedBlockCert, Elapsed> {
+    // Algod V1 documentation states that the round format is 'integer (int64)',
+    // but it's actually an int64 integer encoded in base36.
+    let round = radix_fmt::radix_36(round).to_string();
+    let client = HttpClient::default();
+
+    tokio::time::timeout(RPC_TIMEOUT, async move {
+        loop {
+            if let Ok(rsp) = client.get_block(rpc_addr, &round).await {
+                if rsp.error_for_status_ref().is_err() {
+                    tracing::trace!("invalid status for the response {:?}", rsp);
+                    continue;
+                }
+                tracing::info!("correct status for the response {:?}", rsp);
+
+                let block = rmp_serde::from_slice(&rsp.bytes().await.unwrap()).unwrap();
+                tracing::info!("block data {:?}", block);
+                return Ok(block);
+            }
+            sleep(Duration::from_secs(1)).await;
+        }
+    })
+    .await?
+}
+
+/// [EncodedBlockCert] defines how get-block response encodes a block and its certificate.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct EncodedBlockCert {
+    /// Block header data.
+    pub block: BlockHeaderMsgPack,
+    /// Certificate.
+    pub cert: Certificate,
+}
+
+/// A Certificate contains a cryptographic proof that agreement was reached on a
+/// given block in a given round.
+///
+/// When a client first joins the network or has fallen behind and needs to catch
+/// up, certificates allow the client to verify that a block someone gives them
+/// is the real one.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Certificate {
+    /// Proposal value.
+    #[serde(default, rename = "prop")]
+    pub proposal: Option<CertificateProposal>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CertificateProposal {
+    /// Block header's hash.
+    #[serde(rename = "dig")]
+    pub block_digest: HashDigest,
+}
+
+/// BlockHeader
+/// Deserialized from MessagePack format.
+///
+/// See [block.go](https://github.com/algorand/go-algorand/blob/master/data/bookkeeping/block.go) for more details.
+// Comments below are simply copied from the go-algorand repo.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BlockHeaderMsgPack {
+    /// RewardsLevel specifies how many rewards, in MicroAlgos, have been distributed
+    /// to each config.Protocol.RewardUnit of MicroAlgos since genesis.
+    #[serde(default)]
+    pub earn: u64,
+
+    /// The FeeSink accepts transaction fees. It can only spend to the incentive pool.
+    #[serde(default, rename = "fees")]
+    pub fee_sink: Option<HashDigest>,
+
+    /// The number of leftover MicroAlgos after the distribution of RewardsRate/rewardUnits
+    /// MicroAlgos for every reward unit in the next round.
+    #[serde(default, rename = "frac")]
+    pub leftover_fraction: u64,
+
+    /// Genesis ID to which this block belongs.
+    #[serde(default, rename = "gen")]
+    pub genensis_id: String,
+
+    /// Genesis hash to which this block belongs.
+    #[serde(default, rename = "gh")]
+    pub genesis_id_hash: Option<HashDigest>,
+
+    /// The hash of the previous block.
+    #[serde(default, rename = "prev")]
+    pub prevous_block_hash: Option<HashDigest>,
+
+    /// Current protocol.
+    #[serde(default, rename = "proto")]
+    pub protocol_current: String,
+
+    /// The number of new MicroAlgos added to the participation stake from rewards at the next round.
+    #[serde(default, rename = "rate")]
+    pub rewards_rate: u64,
+
+    /// Round represents a protocol round index.
+    #[serde(default, rename = "rnd")]
+    pub round: u64,
+
+    /// The round at which the RewardsRate will be recalculated.
+    #[serde(default, rename = "rwcalr")]
+    pub rewards_rate_recalc_round: u64,
+
+    /// The RewardsPool accepts periodic injections from the FeeSink and continually
+    /// redistributes them to addresses as rewards.
+    #[serde(default, rename = "rwd")]
+    pub rewards_pool: Option<HashDigest>,
+
+    /// Sortition seed.
+    #[serde(
+        default,
+        rename = "seed",
+        deserialize_with = "deserialize_byte32_arr_opt"
+    )]
+    pub sortition_seed: Option<[u8; 32]>,
+
+    /// TimeStamp in seconds since epoch.
+    #[serde(default, rename = "ts")]
+    pub timestamp: i64,
+
+    /// Root of transaction merkle tree using SHA512_256 hash function.
+    /// This commitment is computed based on the PaysetCommit type specified in the block's consensus protocol.
+    #[serde(default, rename = "txn")]
+    pub tx_merke_root_hash: Option<HashDigest>,
+
+    /// Root of transaction vector commitment merkle tree using SHA256 hash function.
+    #[serde(default, rename = "txn256")]
+    pub tx_merke_root_hash256: Option<HashDigest>,
+}
+
+/// A SHA512_256 hash.
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct HashDigest(pub [u8; 32]);
+
+impl Display for HashDigest {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", BASE64.encode(&self.0))
+    }
+}
+
+impl Debug for HashDigest {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", BASE32_NOPAD.encode(&self.0))
+    }
+}
+
+impl Serialize for HashDigest {
+    fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(&self.0[..])
+    }
+}
+
+impl<'de> Deserialize<'de> for HashDigest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(HashDigest(deserializer.deserialize_bytes(VisitorU8_32)?))
+    }
+}
+
+pub struct VisitorU8_32;
+
+impl<'de> Visitor<'de> for VisitorU8_32 {
+    type Value = [u8; 32];
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("expecting a 32 byte array")
+    }
+
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        if v.len() != 32 {
+            return Err(E::custom(format!("Invalid byte array length: {}", v.len())));
+        }
+
+        let mut bytes = [0; 32];
+        bytes.copy_from_slice(v);
+        Ok(bytes)
+    }
+}
+
+pub fn deserialize_byte32_arr_opt<'de, D>(deserializer: D) -> Result<Option<[u8; 32]>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(match <Option<&[u8]>>::deserialize(deserializer)? {
+        Some(slice) => Some(slice.try_into().map_err(D::Error::custom)?),
+        None => None,
+    })
+}


### PR DESCRIPTION
- C003 test: Performs a handshake and then it fetches a block from the node using the V1 algod API (the same way the node asks for blocks after it initiates a handshake towards the synth node).
- Implemented RPC call to fetch blocks.
- SPEC.md updated.