### PR TITLE
chore: optimize c003 test and use `expect`

### DIFF
--- a/src/setup/config.rs
+++ b/src/setup/config.rs
@@ -66,20 +66,20 @@ impl NodeConfig {
             rest_addr = NodeConfig::try_read_to_string(&rest_addr_path).await;
         })
         .await
-        .expect("Couldn't fetch node's addresses");
+        .expect("couldn't fetch node's addresses");
 
         self.net_addr = Some(
             SocketAddr::from_str(
                 net_addr
                     .trim()
                     .strip_prefix("http://")
-                    .expect("The http prefix is missing."),
+                    .expect("the http prefix is missing"),
             )
-            .expect("Couldn't create the network socket address."),
+            .expect("couldn't create the network socket address"),
         );
         self.rest_api_addr = Some(
             SocketAddr::from_str(rest_addr.trim())
-                .expect("Couldn't create the REST API socket address."),
+                .expect("couldn't create the REST API socket address"),
         );
         Ok(())
     }

--- a/src/setup/node.rs
+++ b/src/setup/node.rs
@@ -100,7 +100,7 @@ impl Node {
     /// Creates a NodeBuilder.
     pub fn builder() -> NodeBuilder {
         NodeBuilder::new()
-            .map_err(|e| format!("Unable to create a builder: {:?}", e))
+            .map_err(|e| format!("unable to create a builder: {:?}", e))
             .unwrap()
     }
 
@@ -159,14 +159,14 @@ impl Node {
             .stdout(stdout)
             .stderr(stderr)
             .spawn()
-            .expect("Node failed to start");
+            .expect("node failed to start");
         self.child = Some(child);
 
         // Once the node is started, fetch its addresses.
         self.conf
             .load_addrs()
             .await
-            .expect("Couldn't load the node's addresses.");
+            .expect("couldn't load the node's addresses");
 
         Node::wait_for_start(self.conf.net_addr.unwrap()).await;
     }
@@ -177,7 +177,7 @@ impl Node {
 
         // Remove address files since addresses may change if the node is restarted.
         let remove_file = |file_name| match fs::remove_file(self.conf.path.join(file_name)) {
-            Err(e) if e.kind() != io::ErrorKind::NotFound => panic!("Unexpected error: {:?}", e),
+            Err(e) if e.kind() != io::ErrorKind::NotFound => panic!("unexpected error: {:?}", e),
             _ => (),
         };
         remove_file(NET_ADDR_FILE);
@@ -241,12 +241,12 @@ mod test {
     #[tokio::test]
     async fn start_stop_the_node() {
         let builder = Node::builder();
-        let target = TempDir::new().expect("Couldn't create a temporary directory");
+        let target = TempDir::new().expect("couldn't create a temporary directory");
 
         let mut node = builder
             .log_to_stdout(false)
             .build(target.path())
-            .expect("Unable to build the node");
+            .expect("unable to build the node");
 
         // No addresses before the node is started.
         assert!(node.rest_api_addr().is_none());

--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -23,18 +23,23 @@ async fn c001_handshake_when_node_receives_connection() {
         .await
         .expect("Unable to build a synthetic node");
 
+    let net_addr = node.net_addr().expect("Network address not found");
+
     // Connect to the node and initiate the handshake.
     synthetic_node
-        .connect(node.net_addr().unwrap())
+        .connect(net_addr)
         .await
-        .unwrap();
+        .expect("Unable to connect");
 
     // This is only set post-handshake (if enabled).
-    assert!(synthetic_node.is_connected(node.net_addr().unwrap()));
+    assert!(
+        synthetic_node.is_connected(net_addr),
+        "Synthetic node is not connected to the node"
+    );
 
     // Gracefully shut down the nodes.
     synthetic_node.shut_down().await;
-    node.stop().unwrap();
+    node.stop().expect("Unable to stop the node");
 }
 
 #[tokio::test]
@@ -50,7 +55,9 @@ async fn c002_handshake_when_node_initiates_connection() {
     // Spin up a node instance.
     let target = TempDir::new().expect("Couldn't create a temporary directory");
     let mut node = Node::builder()
-        .initial_peers([synthetic_node.listening_addr().unwrap()])
+        .initial_peers([synthetic_node
+            .listening_addr()
+            .expect("Listening address not found")])
         .build(target.path())
         .expect("Unable to build the node");
     node.start().await;
@@ -61,13 +68,19 @@ async fn c002_handshake_when_node_initiates_connection() {
 
     // Check the connection has been established (this is only set post-handshake). We can't check
     // for the addr as nodes use ephemeral addresses when initiating connections.
-    assert_ne!(node_addr, node.net_addr().unwrap());
+    assert_ne!(
+        node_addr,
+        node.net_addr().expect("Network address not found")
+    );
 
     // The node sends multiple get_block HTTP queries from different TCP sockets in parallel,
     // so on rare occasions we might have additional few short-lasting connections.
-    assert!(synthetic_node.num_connected() >= 1);
+    assert!(
+        synthetic_node.num_connected() >= 1,
+        "At least one connection is expected"
+    );
 
     // Gracefully shut down the nodes.
     synthetic_node.shut_down().await;
-    node.stop().unwrap();
+    node.stop().expect("Unable to stop the node");
 }

--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -11,35 +11,35 @@ async fn c001_handshake_when_node_receives_connection() {
     // ZG-CONFORMANCE-001
 
     // Spin up a node instance.
-    let target = TempDir::new().expect("Couldn't create a temporary directory");
+    let target = TempDir::new().expect("couldn't create a temporary directory");
     let mut node = Node::builder()
         .build(target.path())
-        .expect("Unable to build the node");
+        .expect("unable to build the node");
     node.start().await;
 
     // Create a synthetic node and enable handshaking.
     let synthetic_node = SyntheticNodeBuilder::default()
         .build()
         .await
-        .expect("Unable to build a synthetic node");
+        .expect("unable to build a synthetic node");
 
-    let net_addr = node.net_addr().expect("Network address not found");
+    let net_addr = node.net_addr().expect("network address not found");
 
     // Connect to the node and initiate the handshake.
     synthetic_node
         .connect(net_addr)
         .await
-        .expect("Unable to connect");
+        .expect("unable to connect");
 
     // This is only set post-handshake (if enabled).
     assert!(
         synthetic_node.is_connected(net_addr),
-        "Synthetic node is not connected to the node"
+        "synthetic node is not connected to the node"
     );
 
     // Gracefully shut down the nodes.
     synthetic_node.shut_down().await;
-    node.stop().expect("Unable to stop the node");
+    node.stop().expect("unable to stop the node");
 }
 
 #[tokio::test]
@@ -50,37 +50,37 @@ async fn c002_handshake_when_node_initiates_connection() {
     let synthetic_node = SyntheticNodeBuilder::default()
         .build()
         .await
-        .expect("Unable to build a synthetic node");
+        .expect("unable to build a synthetic node");
 
     // Spin up a node instance.
-    let target = TempDir::new().expect("Couldn't create a temporary directory");
+    let target = TempDir::new().expect("couldn't create a temporary directory");
     let mut node = Node::builder()
         .initial_peers([synthetic_node
             .listening_addr()
-            .expect("Listening address not found")])
+            .expect("listening address not found")])
         .build(target.path())
-        .expect("Unable to build the node");
+        .expect("unable to build the node");
     node.start().await;
 
     let node_addr = timeout(CONNECTION_TIMEOUT, synthetic_node.wait_for_connection())
         .await
-        .expect("Couldn't establish a connection");
+        .expect("couldn't establish a connection");
 
     // Check the connection has been established (this is only set post-handshake). We can't check
     // for the addr as nodes use ephemeral addresses when initiating connections.
     assert_ne!(
         node_addr,
-        node.net_addr().expect("Network address not found")
+        node.net_addr().expect("network address not found")
     );
 
     // The node sends multiple get_block HTTP queries from different TCP sockets in parallel,
     // so on rare occasions we might have additional few short-lasting connections.
     assert!(
         synthetic_node.num_connected() >= 1,
-        "At least one connection is expected"
+        "at least one connection is expected"
     );
 
     // Gracefully shut down the nodes.
     synthetic_node.shut_down().await;
-    node.stop().expect("Unable to stop the node");
+    node.stop().expect("unable to stop the node");
 }

--- a/src/tests/conformance/post_handshake/query/get_block.rs
+++ b/src/tests/conformance/post_handshake/query/get_block.rs
@@ -11,54 +11,54 @@ async fn c003_V1_BLOCK_ROUND_get_block() {
     // ZG-CONFORMANCE-003
 
     // Spin up a node instance.
-    let target = TempDir::new().expect("Couldn't create a temporary directory");
+    let target = TempDir::new().expect("couldn't create a temporary directory");
     let mut node = Node::builder()
         .build(target.path())
-        .expect("Unable to build the node");
+        .expect("unable to build the node");
     node.start().await;
 
     // Create a synthetic node and enable handshaking.
     let synthetic_node = SyntheticNodeBuilder::default()
         .build()
         .await
-        .expect("Unable to build a synthetic node");
+        .expect("unable to build a synthetic node");
 
-    let net_addr = node.net_addr().expect("Network address not found");
+    let net_addr = node.net_addr().expect("network address not found");
 
     // Connect to the node and initiate the handshake.
     synthetic_node
         .connect(net_addr)
         .await
-        .expect("Unable to connect");
+        .expect("unable to connect");
 
     let rpc_addr = net_addr.to_string();
 
     for round in [0, 1] {
         let block_cert = rpc::wait_for_block(&rpc_addr, round)
             .await
-            .expect("Couldn't get a block");
+            .expect("couldn't get a block");
 
-        assert_eq!(round, block_cert.block.round, "Invalid round");
-        assert!(block_cert.block.sortition_seed.is_some(), "Seed not found");
+        assert_eq!(round, block_cert.block.round, "invalid round");
+        assert!(block_cert.block.sortition_seed.is_some(), "seed not found");
         assert!(
             block_cert.block.genesis_id_hash.is_some(),
-            "Genesis hash not found"
+            "genesis hash not found"
         );
 
         if round == 0 {
             assert!(
                 block_cert.block.prevous_block_hash.is_none(),
-                "Previous block hash shouldn't be found for the first round"
+                "previous block hash shouldn't be found for the first round"
             );
         } else {
             assert!(
                 block_cert.block.prevous_block_hash.is_some(),
-                "Previous block hash not found"
+                "previous block hash not found"
             );
         }
     }
 
     // Gracefully shut down the nodes.
     synthetic_node.shut_down().await;
-    node.stop().expect("Unable to stop the node");
+    node.stop().expect("unable to stop the node");
 }

--- a/src/tests/conformance/post_handshake/query/get_block.rs
+++ b/src/tests/conformance/post_handshake/query/get_block.rs
@@ -33,37 +33,30 @@ async fn c003_V1_BLOCK_ROUND_get_block() {
 
     let rpc_addr = net_addr.to_string();
 
-    // Get block for the round 0.
-    let round = 0;
-    let block_cert = rpc::wait_for_block(&rpc_addr, round)
-        .await
-        .expect("Couldn't get a block");
-    assert_eq!(round, block_cert.block.round, "Invalid round");
-    assert!(block_cert.block.sortition_seed.is_some(), "Seed not found");
-    assert!(
-        block_cert.block.genesis_id_hash.is_some(),
-        "Genesis hash not found"
-    );
-    assert!(
-        block_cert.block.prevous_block_hash.is_none(),
-        "Previous block hash shouldn't be found for the first block"
-    );
+    for round in [0, 1] {
+        let block_cert = rpc::wait_for_block(&rpc_addr, round)
+            .await
+            .expect("Couldn't get a block");
 
-    // Get block for the round 1.
-    let round = 1;
-    let block_cert = rpc::wait_for_block(&rpc_addr, round)
-        .await
-        .expect("Couldn't get a block");
-    assert_eq!(round, block_cert.block.round, "Invalid round");
-    assert!(block_cert.block.sortition_seed.is_some(), "Seed not found");
-    assert!(
-        block_cert.block.genesis_id_hash.is_some(),
-        "Genesis hash not found"
-    );
-    assert!(
-        block_cert.block.prevous_block_hash.is_some(),
-        "Previous block hash not found"
-    );
+        assert_eq!(round, block_cert.block.round, "Invalid round");
+        assert!(block_cert.block.sortition_seed.is_some(), "Seed not found");
+        assert!(
+            block_cert.block.genesis_id_hash.is_some(),
+            "Genesis hash not found"
+        );
+
+        if round == 0 {
+            assert!(
+                block_cert.block.prevous_block_hash.is_none(),
+                "Previous block hash shouldn't be found for the first round"
+            );
+        } else {
+            assert!(
+                block_cert.block.prevous_block_hash.is_some(),
+                "Previous block hash not found"
+            );
+        }
+    }
 
     // Gracefully shut down the nodes.
     synthetic_node.shut_down().await;

--- a/src/tools/rpc.rs
+++ b/src/tools/rpc.rs
@@ -1,3 +1,10 @@
+//! A REST API implementation is named RPC in the go-algorand code base. To maintain parity
+//! with the go-algorand codebase, the file is named RPC here.
+//!
+//! There are two REST API versions for algod:
+//! - [V1](https://developer.algorand.org/docs/rest-apis/algod/v1/) - which is deprecated but still used by the node.
+//! - [V2](https://developer.algorand.org/docs/rest-apis/algod/v2/)
+
 use std::{
     fmt::{self, Display, Formatter},
     time::Duration,
@@ -59,6 +66,8 @@ pub async fn wait_for_block(rpc_addr: &str, round: u64) -> Result<EncodedBlockCe
                 tracing::info!("block data {:?}", block);
                 return Ok(block);
             }
+
+            // On average, new blocks are generated every 4 seconds, so a long wait is fine here.
             sleep(Duration::from_secs(1)).await;
         }
     })


### PR DESCRIPTION
~Two commits:~
EDIT:
Three commits:

```git
chore: optimize c003 test

- include extra comments for the rpc.rs file
```

```
chore: avoid using unwrap

- rather expect everything :^)
```
```
chore: align crash message styles

- expect/panic/assert messages should all be lower-case messages
```