### PR TITLE
feat: c003 test - expect no msgs before the handshake

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -93,6 +93,11 @@ The test index makes use of symbolic language in describing connection and messa
 
 ### ZG-CONFORMANCE-003
 
+    The node should *NOT* send any messages after connection if there was no handshake.
+    The test waits for the predefined amount of time, ensuring no messages were received.
+
+### ZG-CONFORMANCE-004
+
     The node responds correctly to a block request message (V1 algod API) which is how newly connected node queries for block data.
 
     <>

--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -91,7 +91,7 @@ async fn c003_t1_expect_no_messages_before_handshake() {
     // ZG-CONFORMANCE-003
     //
     // A synthetic node with a disabled handshake procedure expects zero messages
-    // after it just connects to the node.
+    // after it initiates a connection with the node.
 
     // Spin up a node instance.
     let target = TempDir::new().expect("couldn't create a temporary directory");
@@ -130,7 +130,7 @@ async fn c003_t2_expect_no_messages_before_handshake() {
     // ZG-CONFORMANCE-003
     //
     // A synthetic node with a disabled handshake procedure expects zero messages
-    // after the node tries to initiate the connection.
+    // after receiving a connection initiated by the node.
 
     // Create a synthetic node and enable handshaking.
     let mut synthetic_node = SyntheticNodeBuilder::default()

--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -1,5 +1,6 @@
 use tempfile::TempDir;
 use tokio::time::timeout;
+use websocket_codec::Message;
 
 use crate::{
     setup::node::Node,
@@ -79,6 +80,77 @@ async fn c002_handshake_when_node_initiates_connection() {
         synthetic_node.num_connected() >= 1,
         "at least one connection is expected"
     );
+
+    // Gracefully shut down the nodes.
+    synthetic_node.shut_down().await;
+    node.stop().expect("unable to stop the node");
+}
+
+#[tokio::test]
+async fn c003_t1_expect_no_messages_before_handshake() {
+    // ZG-CONFORMANCE-003
+    //
+    // A synthetic node with a disabled handshake procedure expects zero messages
+    // after it just connects to the node.
+
+    // Spin up a node instance.
+    let target = TempDir::new().expect("couldn't create a temporary directory");
+    let mut node = Node::builder()
+        .build(target.path())
+        .expect("unable to build the node");
+    node.start().await;
+
+    // Create a synthetic node and enable handshaking.
+    let mut synthetic_node = SyntheticNodeBuilder::default()
+        .with_handshake(false)
+        .build()
+        .await
+        .expect("unable to build a synthetic node");
+
+    let net_addr = node.net_addr().expect("network address not found");
+
+    // Connect to the node and initiate the handshake.
+    synthetic_node
+        .connect(net_addr)
+        .await
+        .expect("unable to connect");
+
+    let expect_any_msg = |_: &Message| true;
+    assert!(!synthetic_node.expect_message(&expect_any_msg).await);
+
+    // Gracefully shut down the nodes.
+    synthetic_node.shut_down().await;
+    node.stop().expect("unable to stop the node");
+}
+
+// TODO(Rqnsom): Maybe this test makes no sense because we do get bombarded with the GET_BLOCK requests,
+// but our Reading thread still doesn't know how to parse those so we get a pea2pea invalid data error.
+#[tokio::test]
+async fn c003_t2_expect_no_messages_before_handshake() {
+    // ZG-CONFORMANCE-003
+    //
+    // A synthetic node with a disabled handshake procedure expects zero messages
+    // after the node tries to initiate the connection.
+
+    // Create a synthetic node and enable handshaking.
+    let mut synthetic_node = SyntheticNodeBuilder::default()
+        .with_handshake(false)
+        .build()
+        .await
+        .expect("unable to build a synthetic node");
+
+    // Spin up a node instance.
+    let target = TempDir::new().expect("couldn't create a temporary directory");
+    let mut node = Node::builder()
+        .initial_peers([synthetic_node
+            .listening_addr()
+            .expect("listening address not found")])
+        .build(target.path())
+        .expect("unable to build the node");
+    node.start().await;
+
+    let expect_any_msg = |_: &Message| true;
+    assert!(!synthetic_node.expect_message(&expect_any_msg).await);
 
     // Gracefully shut down the nodes.
     synthetic_node.shut_down().await;

--- a/src/tests/conformance/post_handshake/query/get_block.rs
+++ b/src/tests/conformance/post_handshake/query/get_block.rs
@@ -7,8 +7,8 @@ use crate::{
 
 #[tokio::test]
 #[allow(non_snake_case)]
-async fn c003_V1_BLOCK_ROUND_get_block() {
-    // ZG-CONFORMANCE-003
+async fn c004_V1_BLOCK_ROUND_get_block() {
+    // ZG-CONFORMANCE-004
 
     // Spin up a node instance.
     let target = TempDir::new().expect("couldn't create a temporary directory");

--- a/src/tools/constants.rs
+++ b/src/tools/constants.rs
@@ -5,5 +5,5 @@ use tokio::time::Duration;
 /// Connection timeout.
 pub const CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// Timeout when waiting for expected message / node's state.
+/// Timeout when waiting for an expected message or a change in the node's state.
 pub const EXPECT_MSG_TIMEOUT: Duration = Duration::from_secs(10);

--- a/src/tools/constants.rs
+++ b/src/tools/constants.rs
@@ -2,5 +2,8 @@
 
 use tokio::time::Duration;
 
-/// Timeout when waiting for expected message / node's state.
+/// Connection timeout.
 pub const CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Timeout when waiting for expected message / node's state.
+pub const EXPECT_MSG_TIMEOUT: Duration = Duration::from_secs(10);


### PR DESCRIPTION
- new `c003` test: expect to receive no messages if the handshake procedure is skipped after the connection is established.
- renamed the old `c003` (`get_blocks`) test to `c004` since the new test is a handshake-related test similar to the `c001` and `c002` tests.