### PR TITLE
Add C005_t2 test: send a MsgOfInterest back to the node

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,4 @@ These results were obtained by running the test suite against [Algorand v3.9.4-s
 | [005](SPEC.md#ZG-CONFORMANCE-005) |   ✓    |                                                                             |
 | [006](SPEC.md#ZG-CONFORMANCE-006) |   -    |                                                                             |
 | [007](SPEC.md#ZG-CONFORMANCE-007) |   ✓    |                                                                             |
+| [008](SPEC.md#ZG-CONFORMANCE-008) |   ✓    |                                                                             |

--- a/SPEC.md
+++ b/SPEC.md
@@ -135,10 +135,11 @@ _TODO: Investigate more REST API calls and possibly include above._
 
 ### ZG-CONFORMANCE-005
 
-    The node sends MsgOfInterest after the handshake.
+    The node and the synthetic node exchange MsgOfInterest messages after the handshake.
 
     <>
     <- MsgOfInterest
+    -> MsgOfInterest
 
 ### ZG-CONFORMANCE-006
 

--- a/src/protocol/codecs/mod.rs
+++ b/src/protocol/codecs/mod.rs
@@ -47,6 +47,6 @@
 pub mod algomsg;
 pub mod msgpack;
 pub mod payload;
-mod tagmsg;
-mod topic;
+pub mod tagmsg;
+pub mod topic;
 pub mod websocket;

--- a/src/protocol/writing.rs
+++ b/src/protocol/writing.rs
@@ -1,14 +1,17 @@
 use std::net::SocketAddr;
 
-use pea2pea::{protocols::Writing, ConnectionSide};
+use pea2pea::{protocols::Writing, ConnectionSide, Pea2Pea};
 
-use crate::{protocol::codecs::websocket::WebsocketCodec, tools::inner_node::InnerNode};
+use crate::{
+    protocol::codecs::{algomsg::AlgoMsgCodec, payload::Payload},
+    tools::inner_node::InnerNode,
+};
 
 impl Writing for InnerNode {
-    type Message = Vec<u8>;
-    type Codec = WebsocketCodec;
+    type Message = Payload;
+    type Codec = AlgoMsgCodec;
 
     fn codec(&self, _addr: SocketAddr, _side: ConnectionSide) -> Self::Codec {
-        Default::default()
+        AlgoMsgCodec::new(self.node().span().clone())
     }
 }

--- a/src/tests/conformance/post_handshake/msg_of_interest.rs
+++ b/src/tests/conformance/post_handshake/msg_of_interest.rs
@@ -1,13 +1,17 @@
+use std::collections::HashSet;
+
 use tempfile::TempDir;
+use tokio::time::Duration;
 
 use crate::{
-    protocol::codecs::payload::Payload, setup::node::Node,
+    protocol::codecs::{payload::Payload, tagmsg::Tag, topic::MsgOfInterest},
+    setup::node::Node,
     tools::synthetic_node::SyntheticNodeBuilder,
 };
 
 #[tokio::test]
 #[allow(non_snake_case)]
-async fn c005_MSG_OF_INTEREST_expect_after_connect() {
+async fn c005_t1_MSG_OF_INTEREST_expect_after_connect() {
     // ZG-CONFORMANCE-005
 
     // Spin up a node instance.
@@ -39,5 +43,66 @@ async fn c005_MSG_OF_INTEREST_expect_after_connect() {
     node.stop().expect("unable to stop the node");
 }
 
-// TODO(Rqnsom): c005_t2: when the node initiates the connection, send MSG_OF_INTEREST with all messages enabled
+#[tokio::test]
+#[allow(non_snake_case)]
+async fn c005_t2_MSG_OF_INTEREST_send_after_connect() {
+    // ZG-CONFORMANCE-005
+
+    // Spin up a node instance.
+    let target = TempDir::new().expect("couldn't create a temporary directory");
+    let mut node = Node::builder()
+        .build(target.path())
+        .expect("unable to build the node");
+    node.start().await;
+
+    // Create a synthetic node and enable handshaking.
+    let mut synthetic_node = SyntheticNodeBuilder::default()
+        .build()
+        .await
+        .expect("unable to build a synthetic node");
+
+    let net_addr = node.net_addr().expect("network address not found");
+
+    // Connect to the node and initiate the handshake.
+    synthetic_node
+        .connect(net_addr)
+        .await
+        .expect("unable to connect");
+
+    // Send a MsgOfInterest message with all expected tags included.
+    let tags = HashSet::from([
+        Tag::ProposalPayload,
+        Tag::AgreementVote,
+        Tag::MsgOfInterest,
+        Tag::MsgDigestSkip,
+        Tag::NetPrioResponse,
+        Tag::Ping,
+        Tag::PingReply,
+        Tag::ProposalPayload,
+        Tag::StateProofSig,
+        Tag::TopicMsgResp,
+        Tag::Txn,
+        Tag::UniEnsBlockReq,
+        Tag::VoteBundle,
+    ]);
+    let message = Payload::MsgOfInterest(MsgOfInterest { tags });
+    assert!(synthetic_node.unicast(net_addr, message).is_ok());
+
+    // Clear any remaining received messages in the inbound queue
+    // received before the node processes our MsgOfInterest message.
+    while synthetic_node
+        .recv_message_timeout(Duration::from_millis(10))
+        .await
+        .is_ok()
+    {}
+
+    // Wait for any message from the 'tags' list above.
+    let expect_any_msg = |_: &Payload| true;
+    assert!(synthetic_node.expect_message(&expect_any_msg).await);
+
+    // Gracefully shut down the nodes.
+    synthetic_node.shut_down().await;
+    node.stop().expect("unable to stop the node");
+}
+
 // TODO(Rqnsom): c006: send MSG_OF_INTEREST with all messages disabled and expect no messages afterwards


### PR DESCRIPTION
Includes three commits:
```
 feat: algomsg/tagmsg/payload codecs - impl Encoder 
```
```
feat: add unicast send for synthetic_node 

- also include recv_message_timeout function
``` 
```
 feat: add c005_t2 test - send a MessageOfInterest 
```