### PR TITLE
feat: add a test-check for a keep-alive service

### DIFF
--- a/src/tests/conformance/post_handshake/query/ping.rs
+++ b/src/tests/conformance/post_handshake/query/ping.rs
@@ -1,4 +1,5 @@
 use tempfile::TempDir;
+use tokio::time::{timeout, Duration};
 
 use crate::{
     protocol::codecs::payload::{Payload, PingData},
@@ -8,7 +9,7 @@ use crate::{
 
 #[tokio::test]
 #[allow(non_snake_case)]
-async fn c009_PING_PING_REPLY_send_req_expect_reply() {
+async fn c009_t1_PING_PING_REPLY_send_req_expect_reply() {
     // ZG-CONFORMANCE-009
 
     // Spin up a node instance.
@@ -44,6 +45,67 @@ async fn c009_PING_PING_REPLY_send_req_expect_reply() {
         synthetic_node.expect_message(&check).await,
         "the PingReply response is missing"
     );
+
+    // Gracefully shut down the nodes.
+    synthetic_node.shut_down().await;
+    node.stop().expect("unable to stop the node");
+}
+
+#[tokio::test]
+#[allow(non_snake_case)]
+#[ignore]
+async fn c009_t2_PING_PING_REPLY_wait_for_a_ping_req() {
+    // ZG-CONFORMANCE-009
+
+    crate::tools::synthetic_node::enable_tracing();
+    // Spin up a node instance.
+    let target = TempDir::new().expect("couldn't create a temporary directory");
+    let mut node = Node::builder()
+        .log_to_stdout(true)
+        .build(target.path())
+        .expect("unable to build the node");
+    node.start().await;
+
+    // Create a synthetic node and enable handshaking.
+    let mut synthetic_node = SyntheticNodeBuilder::default()
+        .build()
+        .await
+        .expect("unable to build a synthetic node");
+
+    let net_addr = node.net_addr().expect("network address not found");
+
+    // Connect to the node and initiate the handshake.
+    synthetic_node
+        .connect(net_addr)
+        .await
+        .expect("unable to connect");
+
+    // TODO: reminder: uncomment or delete eventually.
+    //// Expect a Ping request.
+    //let check = |m: &Payload| matches!(&m, Payload::Ping(_));
+    //assert!(
+    //    synthetic_node.expect_message(&check).await,
+    //    "the Ping request is missing"
+    //);
+
+    // Alternative approach at the moment: wait for any non-broadcast message:
+    // Filter out the MsgOfInterest message.
+    let check = |m: &Payload| matches!(&m, Payload::MsgOfInterest(..));
+    assert!(synthetic_node.expect_message(&check).await);
+    // Wait for at least 10 minutes.
+    assert!(timeout(Duration::from_secs(610), async {
+        loop {
+            match synthetic_node.recv_message().await {
+                (_, Payload::AgreementVote(_) | Payload::ProposalPayload(_)) => continue,
+                msg => {
+                    tracing::info!("Received a message: {:?}", msg);
+                    return true;
+                }
+            }
+        }
+    })
+    .await
+    .is_ok());
 
     // Gracefully shut down the nodes.
     synthetic_node.shut_down().await;


### PR DESCRIPTION
- a test which waits for any non-broadcast message within the first ten minutes after the handshake.