### PR TITLE
Setup script update - increase max_conn_limit_per_ip, generate at least 4 rounds in the PN

### DIFF
--- a/src/tests/conformance/post_handshake/query/get_block.rs
+++ b/src/tests/conformance/post_handshake/query/get_block.rs
@@ -37,7 +37,7 @@ async fn c004_V1_BLOCK_ROUND_get_block() {
 
     let rpc_addr = net_addr.to_string();
 
-    for round in [0, 1] {
+    for round in 0..4 {
         let block_cert = rpc::wait_for_block(&rpc_addr, round)
             .await
             .expect("couldn't get a block");
@@ -72,11 +72,9 @@ async fn c004_V1_BLOCK_ROUND_get_block() {
 async fn c010_UNI_ENS_BLOCK_REQ_get_block() {
     // ZG-CONFORMANCE-010
 
-    crate::tools::synthetic_node::enable_tracing();
     // Spin up a node instance.
     let target = TempDir::new().expect("couldn't create a temporary directory");
     let mut node = Node::builder()
-        .log_to_stdout(true)
         .build(target.path())
         .expect("unable to build the node");
     node.start().await;
@@ -95,7 +93,6 @@ async fn c010_UNI_ENS_BLOCK_REQ_get_block() {
         .await
         .expect("unable to connect");
 
-    // TODO: run the node in setup_env.sh for at least 5 seconds longer to have a few more rounds ready.
     for round in 0..4 {
         let message = Payload::UniEnsBlockReq(UniEnsBlockReq {
             data_type: UniEnsBlockReqType::BlockAndCert,

--- a/tools/setup_env.sh
+++ b/tools/setup_env.sh
@@ -64,6 +64,9 @@ update_config_file() {
 
     # The default (unspecified) base log level is 4 (info). Use the most verbose log level 5 (debug / verbose) instead.
     echo "$(awk 'NR==3{print "\t\"BaseLoggerDebugLevel\": 5,"}1' $CFG_FILE)" > $CFG_FILE # see [3]
+
+    # The default value is 30. The other workaround is using different 127.0.x.x addresses, but this is easier.
+    echo "$(awk 'NR==3{print "\t\"MaxConnectionsPerIP\": 900,"}1' $CFG_FILE)" > $CFG_FILE # see [3]
 }
 
 # Verify the algod binary path using the version option


### PR DESCRIPTION
 Two commits:
```
chore: increase setup_env.sh max_conn_limit_per_ip 

Increasing the limit will make performance testing easier.
```

```
chore: setup_env.sh - run the private network for 20 secs

- Running the private network for 20 seconds will ensure that at
  least four rounds are created in that time (which is needed
  for certain tests).
- update c004 test to use the first four rounds
```