### PR TITLE
feat: UNI_ENS_BLOCK_REQ tests for all req-types

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,4 @@ These results were obtained by running the test suite against [Algorand v3.9.4-s
 | [007](SPEC.md#ZG-CONFORMANCE-007) |   ✓    |                                                                             |
 | [008](SPEC.md#ZG-CONFORMANCE-008) |   ✓    |                                                                             |
 | [009](SPEC.md#ZG-CONFORMANCE-009) |   ✖    | The PingReply handler doesn't exist anymore in the go-algorand codebase     |
-| [010](SPEC.md#ZG-CONFORMANCE-010) |   ✓    |                                                                             |
+| [010](SPEC.md#ZG-CONFORMANCE-010) |  ✓/✖   | Only BlockAndCert request is supported, other type requests are unsupported |

--- a/src/protocol/codecs/topic.rs
+++ b/src/protocol/codecs/topic.rs
@@ -32,8 +32,7 @@ pub struct MsgOfInterest {
 }
 
 /// Universal block request types.
-#[derive(Debug, Clone)]
-#[allow(dead_code)] // TODO: write a test for unused ones.
+#[derive(Debug, Copy, Clone)]
 pub enum UniEnsBlockReqType {
     /// Block-data topic-key in the response.
     Block,


### PR DESCRIPTION
- original test which expects both block and request is renamed to t1
- t2 added: expects block only in the request
- t3 added: expects cert only in the request