### PR TITLE
feat: test for the UniCatchupReq msg 

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -89,7 +89,7 @@ The fuzz tests aim to buttress the message conformance tests with extra verifica
 | PingReplyTag               | WS data (Tag: pj)     | ✅       | `C009`                            |
 | ProposalPayloadTag         | WS data (Tag: PP)     | ✅       | `C007`                            |
 | StateProofSigTag           | WS data (Tag: SP)     | ❌       |                                   |
-| UniCatchupReqTag           | WS data (Tag: UC)     | ❌       |                                   |
+| UniCatchupReqTag           | WS data (Tag: UC)     | ✅       | `C010`                            |
 | UniEnsBlockReqTag          | WS data (Tag: UE)     | ✅       | `C010`                            |
 | TopicMsgRespTag            | WS data (Tag: TS)     | ✅       | `C010`                            |
 | TxnTag                     | WS data (Tag: TX)     | ❌       |                                   |
@@ -181,10 +181,11 @@ _TODO: Investigate more REST API calls and possibly include above._
 
 ### ZG-CONFORMANCE-010
 
-    The node responds correctly to a block request message for the UniEnsBlockReq message request.
+    The node responds correctly to a block request message for the UniEnsBlockReq/UniCatchupReq message request.
 
     <>
-    -> UniEnsBlockReq
+    -> UniEnsBlockReq / UniCatchupReq
     <- TopicMsgResp
 
     Assert: the response contains block for a requested round.
+

--- a/src/protocol/codecs/payload.rs
+++ b/src/protocol/codecs/payload.rs
@@ -8,7 +8,7 @@ use crate::protocol::{
     codecs::{
         msgpack::{AgreementVote, ProposalPayload},
         tagmsg::Tag,
-        topic::{MsgOfInterest, TopicCodec, TopicMsgResp, UniEnsBlockReq},
+        topic::{MsgOfInterest, TopicCodec, TopicMsgResp, UniCatchupReq, UniEnsBlockReq},
     },
     invalid_data,
 };
@@ -23,6 +23,7 @@ pub enum Payload {
     Ping(PingData),
     PingReply(PingData),
     UniEnsBlockReq(UniEnsBlockReq),
+    UniCatchupReq(UniCatchupReq),
     TopicMsgResp(TopicMsgResp),
     NotImplemented,
 }
@@ -94,7 +95,7 @@ impl Encoder<Payload> for PayloadCodec {
 
     fn encode(&mut self, message: Payload, dst: &mut BytesMut) -> Result<(), Self::Error> {
         let raw_data = match message {
-            Payload::MsgOfInterest(_) | Payload::UniEnsBlockReq(_) => {
+            Payload::MsgOfInterest(_) | Payload::UniEnsBlockReq(_) | Payload::UniCatchupReq(_) => {
                 return self
                     .topic
                     .encode(message, dst)

--- a/src/protocol/codecs/tagmsg.rs
+++ b/src/protocol/codecs/tagmsg.rs
@@ -95,6 +95,7 @@ impl From<&Payload> for Tag {
             Payload::Ping(_) => Self::Ping,
             Payload::PingReply(_) => Self::PingReply,
             Payload::UniEnsBlockReq(_) => Self::UniEnsBlockReq,
+            Payload::UniCatchupReq(_) => Self::UniCatchupReq,
             Payload::TopicMsgResp(_) => Self::TopicMsgResp,
             Payload::NotImplemented => Self::UnknownMsg,
         }

--- a/src/tests/conformance/post_handshake/query/get_block.rs
+++ b/src/tests/conformance/post_handshake/query/get_block.rs
@@ -3,7 +3,7 @@ use tempfile::TempDir;
 use crate::{
     protocol::codecs::{
         payload::Payload,
-        topic::{TopicMsgResp, UniEnsBlockReq, UniEnsBlockReqType},
+        topic::{TopicMsgResp, UniCatchupReq, UniEnsBlockReq, UniEnsBlockReqType},
     },
     setup::node::Node,
     tools::{rpc, synthetic_node::SyntheticNodeBuilder},
@@ -272,6 +272,120 @@ async fn c010_t4_UNI_ENS_BLOCK_REQ_cannot_get_non_existent_block() {
         synthetic_node.expect_message(&check).await,
         "the UniEnsBlockRsp response is missing"
     );
+
+    // Gracefully shut down the nodes.
+    synthetic_node.shut_down().await;
+    node.stop().expect("unable to stop the node");
+}
+
+#[tokio::test]
+#[allow(non_snake_case)]
+async fn c010_t5_UNI_CATCHUP_REQ_get_block_all_variations() {
+    // ZG-CONFORMANCE-010
+    //
+    // This test is based on t1-t4 tests, since UniCatchupReq behaves exactly the same as the
+    // UniEnsBlockReq message. So, all subtests for this message are grouped together here.
+
+    // Spin up a node instance.
+    let target = TempDir::new().expect("couldn't create a temporary directory");
+    let mut node = Node::builder()
+        .build(target.path())
+        .expect("unable to build the node");
+    node.start().await;
+
+    // Create a synthetic node and enable handshaking.
+    let mut synthetic_node = SyntheticNodeBuilder::default()
+        .build()
+        .await
+        .expect("unable to build a synthetic node");
+
+    let net_addr = node.net_addr().expect("network address not found");
+
+    // Connect to the node and initiate the handshake.
+    synthetic_node
+        .connect(net_addr)
+        .await
+        .expect("unable to connect");
+
+    let round = 1; // A random value from the 0..4 range.
+
+    // Get a block and certificate (as in the t1 test).
+    {
+        let message = Payload::UniCatchupReq(UniCatchupReq {
+            data_type: UniEnsBlockReqType::BlockAndCert,
+            round_key: round,
+            nonce: round,
+        });
+        assert!(synthetic_node.unicast(net_addr, message).is_ok());
+        // Expect a UniEnsBlockRsp response with a block with the same round and also a certificate.
+        let check = |m: &Payload| {
+            matches!(&m, Payload::TopicMsgResp(TopicMsgResp::UniEnsBlockRsp(rsp))
+                     if rsp.block.is_some() && rsp.block.as_ref().unwrap().round == round && rsp.cert.is_some())
+        };
+        assert!(
+            synthetic_node.expect_message(&check).await,
+            "the UniEnsBlockRsp response is missing"
+        );
+    }
+
+    // Get only a block (as in the t2 test).
+    {
+        let message = Payload::UniCatchupReq(UniCatchupReq {
+            data_type: UniEnsBlockReqType::Block,
+            round_key: round,
+            nonce: round,
+        });
+        assert!(synthetic_node.unicast(net_addr, message).is_ok());
+        // TODO: Still unsupported, check with the Algorand team.
+        // Alternative check to ensure it's unsupported :-)
+        let check = |m: &Payload| {
+            matches!(&m, Payload::TopicMsgResp(TopicMsgResp::ErrorRsp(rsp))
+                     if rsp.error.as_str() == "requested data type is unsupported")
+        };
+        assert!(
+            synthetic_node.expect_message(&check).await,
+            "the UniEnsBlockRsp response is missing"
+        );
+    }
+
+    // Get only a certificate (as in the t3 test).
+    {
+        let message = Payload::UniCatchupReq(UniCatchupReq {
+            data_type: UniEnsBlockReqType::Cert,
+            round_key: round,
+            nonce: round,
+        });
+        assert!(synthetic_node.unicast(net_addr, message).is_ok());
+        // TODO: Still unsupported, check with the Algorand team.
+        // Alternative check to ensure it's unsupported :-)
+        let check = |m: &Payload| {
+            matches!(&m, Payload::TopicMsgResp(TopicMsgResp::ErrorRsp(rsp))
+                     if rsp.error.as_str() == "requested data type is unsupported")
+        };
+        assert!(
+            synthetic_node.expect_message(&check).await,
+            "the UniEnsBlockRsp response is missing"
+        );
+    }
+
+    // Ask for a non-existent block and get a valid response (as in the t4 test).
+    {
+        let message = Payload::UniCatchupReq(UniCatchupReq {
+            data_type: UniEnsBlockReqType::BlockAndCert,
+            round_key: 9999,
+            nonce: 0,
+        });
+        assert!(synthetic_node.unicast(net_addr, message).is_ok());
+
+        let check = |m: &Payload| {
+            matches!(&m, Payload::TopicMsgResp(TopicMsgResp::ErrorRsp(rsp))
+                     if rsp.error.as_str() == "requested block is not available")
+        };
+        assert!(
+            synthetic_node.expect_message(&check).await,
+            "the UniEnsBlockRsp response is missing"
+        );
+    }
 
     // Gracefully shut down the nodes.
     synthetic_node.shut_down().await;


### PR DESCRIPTION
```
feat: add codec support for UniCatchupReq msg
```
```
feat: get_block c010 subtests for UniCatchupReq msg

- All tests are based on existing t1-t4 for UniEnsBlockReq message
  which has the same structure.
- SPEC doc updated accordingly.
```