### PR TITLE
deps: uplift pea2pea to 0.43

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ fs_extra = "1.2"
 futures-util = { version = "0.3", features = ["sink"] }
 home = "0.5.3"
 httparse = "1.8"
-pea2pea = "0.40"
+pea2pea = "0.43"
 radix_fmt = "1.0"
 reqwest = { version = "0.11" }
 rmp-serde = "1.0.0"

--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -53,12 +53,15 @@ async fn c002_handshake_when_node_initiates_connection() {
         .await
         .expect("unable to build a synthetic node");
 
+    let listening_addr = synthetic_node
+        .start_listening()
+        .await
+        .expect("a synthetic node couldn't start listening");
+
     // Spin up a node instance.
     let target = TempDir::new().expect("couldn't create a temporary directory");
     let mut node = Node::builder()
-        .initial_peers([synthetic_node
-            .listening_addr()
-            .expect("listening address not found")])
+        .initial_peers([listening_addr])
         .build(target.path())
         .expect("unable to build the node");
     node.start().await;
@@ -139,12 +142,15 @@ async fn c003_t2_expect_no_messages_before_handshake() {
         .await
         .expect("unable to build a synthetic node");
 
+    let listening_addr = synthetic_node
+        .start_listening()
+        .await
+        .expect("a synthetic node couldn't start listening");
+
     // Spin up a node instance.
     let target = TempDir::new().expect("couldn't create a temporary directory");
     let mut node = Node::builder()
-        .initial_peers([synthetic_node
-            .listening_addr()
-            .expect("listening address not found")])
+        .initial_peers([listening_addr])
         .build(target.path())
         .expect("unable to build the node");
     node.start().await;

--- a/src/tests/conformance/post_handshake/net_prio_response.rs
+++ b/src/tests/conformance/post_handshake/net_prio_response.rs
@@ -25,12 +25,15 @@ async fn c011_t1_NET_PRIO_RESPONSE_expect_rsp_from_the_node() {
         .await
         .expect("unable to build a synthetic node");
 
+    let listening_addr = synthetic_node
+        .start_listening()
+        .await
+        .expect("a synthetic node couldn't start listening");
+
     // Spin up a node instance.
     let target = TempDir::new().expect("couldn't create a temporary directory");
     let mut node = Node::builder()
-        .initial_peers([synthetic_node
-            .listening_addr()
-            .expect("listening address not found")])
+        .initial_peers([listening_addr])
         .build(target.path())
         .expect("unable to build the node");
     node.start().await;
@@ -51,7 +54,7 @@ async fn c011_t1_NET_PRIO_RESPONSE_expect_rsp_from_the_node() {
 async fn c011_t2_NET_PRIO_RESPONSE_no_rsp_if_challenge_not_sent() {
     // ZG-CONFORMANCE-011
     //
-    // Do not send a challenge when answering to a handshake request.
+    // Do not send a challenge when answering a handshake request.
     // A NetPrioResponse message should not be received in that case.
 
     // Create a synthetic node and enable handshaking.
@@ -60,12 +63,15 @@ async fn c011_t2_NET_PRIO_RESPONSE_no_rsp_if_challenge_not_sent() {
         .await
         .expect("unable to build a synthetic node");
 
+    let listening_addr = synthetic_node
+        .start_listening()
+        .await
+        .expect("a synthetic node couldn't start listening");
+
     // Spin up a node instance.
     let target = TempDir::new().expect("couldn't create a temporary directory");
     let mut node = Node::builder()
-        .initial_peers([synthetic_node
-            .listening_addr()
-            .expect("listening address not found")])
+        .initial_peers([listening_addr])
         .build(target.path())
         .expect("unable to build the node");
     node.start().await;

--- a/src/tools/synthetic_node.rs
+++ b/src/tools/synthetic_node.rs
@@ -58,7 +58,7 @@ impl SyntheticNodeBuilder {
     /// Creates a [`SyntheticNode`] with the current configuration.
     pub async fn build(&self) -> io::Result<SyntheticNode> {
         // Create the pea2pea node from the config.
-        let node = Node::new(self.network_config.clone()).await?;
+        let node = Node::new(self.network_config.clone());
 
         // Inbound channel size of 100 messages.
         let (tx, rx) = mpsc::channel(100);
@@ -104,6 +104,13 @@ impl SyntheticNode {
     /// If the handshake protocol is enabled it will be executed as well.
     pub async fn connect(&self, target: SocketAddr) -> io::Result<()> {
         self.inner.node().connect(target).await
+    }
+
+    /// Starts listening for inbound connections.
+    ///
+    /// Returns the listening socket address.
+    pub async fn start_listening(&self) -> io::Result<SocketAddr> {
+        self.inner.node().start_listening().await
     }
 
     /// Indicates if the `addr` is registered as a connected peer.


### PR DESCRIPTION
- added required support for a `start_listening()` method for the `SyntheticNode`
- tests updated according to this change