### PR TITLE
chore: change way of starting algod process

### DIFF
--- a/src/setup/node.rs
+++ b/src/setup/node.rs
@@ -152,7 +152,8 @@ impl Node {
             self.meta.start_args.push(ip_list.into());
         }
 
-        let child = Command::new(&self.meta.start_command)
+        let full_path = fs::canonicalize(self.meta.path.join(&self.meta.start_command)).unwrap();
+        let child = Command::new(full_path)
             .current_dir(&self.meta.path)
             .args(&self.meta.start_args)
             .stdin(Stdio::null())

--- a/tools/setup_env.sh
+++ b/tools/setup_env.sh
@@ -35,7 +35,7 @@ setup_config_file() {
     echo "# Algorand installation path" > $ZIGGURAT_ALGORAND_SETUP_CFG_FILE
     echo "path = \"$ALGORAND_BIN_PATH\"" >> $ZIGGURAT_ALGORAND_SETUP_CFG_FILE
     echo "# Start command with possible arguments" >> $ZIGGURAT_ALGORAND_SETUP_CFG_FILE
-    echo "start_command = \"$ALGOD_BIN_NAME\"" >> $ZIGGURAT_ALGORAND_SETUP_CFG_FILE
+    echo "start_command = \"./$ALGOD_BIN_NAME\"" >> $ZIGGURAT_ALGORAND_SETUP_CFG_FILE
 
     # Print file contents so the user can check whether the path is correct
     cat $ZIGGURAT_ALGORAND_SETUP_CFG_FILE


### PR DESCRIPTION
Commands should begin with ./ to be properly executed under Linux.
To do so, setup_env script need to be fixed.