### PR TITLE
feat: introduce proper algod addresses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ pea2pea = "0.43"
 radix_fmt = "1.0"
 reqwest = { version = "0.11" }
 rmp-serde = "1.0.0"
+sha2 = "0.10"
 tempfile = "3.3"
 tokio-tungstenite = "0.17"
 tokio-util = { version = "0.7", features = ["codec"] }


### PR DESCRIPTION
- use algod addresses with a checksum that are encoded in base64 format
- update existing addresses to use `Address` instead of `HashDigest`

Some of the code has been copied from [here](https://github.com/manuelmauro/algonaut/tree/main/algonaut_core/src/lib.rs). Algonaut is an excellent tool!