### PR TITLE
feat: support for msgpack deserializing txn msgs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ pea2pea = "0.43"
 radix_fmt = "1.0"
 reqwest = { version = "0.11" }
 rmp-serde = "1.0.0"
+serde_bytes = "0.11"
 sha2 = "0.10"
 tempfile = "3.3"
 tokio-tungstenite = "0.17"

--- a/src/protocol/codecs/payload.rs
+++ b/src/protocol/codecs/payload.rs
@@ -6,7 +6,7 @@ use tracing::Span;
 
 use crate::protocol::{
     codecs::{
-        msgpack::{AgreementVote, HashDigest, NetPrioResponse, ProposalPayload},
+        msgpack::{AgreementVote, HashDigest, NetPrioResponse, ProposalPayload, SignedTransaction},
         tagmsg::Tag,
         topic::{MsgOfInterest, TopicCodec, TopicMsgResp, UniCatchupReq, UniEnsBlockReq},
     },
@@ -27,6 +27,7 @@ pub enum Payload {
     TopicMsgResp(TopicMsgResp),
     NetPrioResponse(NetPrioResponse),
     MsgDigestSkip(HashDigest),
+    Transaction(SignedTransaction),
     NotImplemented,
 }
 
@@ -94,6 +95,10 @@ impl Decoder for PayloadCodec {
                     invalid_data!("couldn't deserialize the NetPrioResponse message")
                 })?)
             }
+            Tag::Txn => Payload::Transaction(
+                rmp_serde::from_slice(src)
+                    .map_err(|_| invalid_data!("couldn't deserialize the Txn message"))?,
+            ),
             _ => return Ok(Some(Payload::NotImplemented)),
         };
 

--- a/src/protocol/codecs/tagmsg.rs
+++ b/src/protocol/codecs/tagmsg.rs
@@ -99,6 +99,7 @@ impl From<&Payload> for Tag {
             Payload::TopicMsgResp(_) => Self::TopicMsgResp,
             Payload::NetPrioResponse(_) => Self::NetPrioResponse,
             Payload::MsgDigestSkip(_) => Self::MsgDigestSkip,
+            Payload::Transaction(_) => Self::Txn,
             Payload::NotImplemented => Self::UnknownMsg,
         }
     }

--- a/src/tools/rpc.rs
+++ b/src/tools/rpc.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use tokio::time::{error::Elapsed, sleep};
 
 use crate::protocol::{
-    codecs::msgpack::{deserialize_byte32_arr_opt, HashDigest},
+    codecs::msgpack::{Ed25519Seed, HashDigest},
     constants::USER_AGENT,
 };
 
@@ -153,12 +153,8 @@ pub struct BlockHeaderMsgPack {
     pub rewards_pool: Option<HashDigest>,
 
     /// Sortition seed.
-    #[serde(
-        default,
-        rename = "seed",
-        deserialize_with = "deserialize_byte32_arr_opt"
-    )]
-    pub sortition_seed: Option<[u8; 32]>,
+    #[serde(rename = "seed", default)]
+    pub sortition_seed: Option<Ed25519Seed>,
 
     /// TimeStamp in seconds since epoch.
     #[serde(default, rename = "ts")]


### PR DESCRIPTION
- adds support for deserializing Transaction messages from the node.
- extra: removed todo - now all fields in the agreementVote and the proposalPayload messages are deserialized.

Some of the code has been copied/modified from [here](https://github.com/manuelmauro/algonaut/tree/main/algonaut_core/src/lib.rs). Algonaut is an excellent tool!