### PR TITLE
introduce start/stop support for kmd

### DIFF
--- a/src/setup/config.rs
+++ b/src/setup/config.rs
@@ -14,7 +14,7 @@ use serde::Deserialize;
 use tokio::time::{sleep, timeout, Duration};
 
 use crate::setup::constants::{
-    LOAD_ADDR_TIMEOUT_SECS, NET_ADDR_FILE, REST_ADDR_FILE, SETUP_CONFIG,
+    LOAD_FILE_TIMEOUT_SECS, NET_ADDR_FILE, REST_ADDR_FILE, SETUP_CONFIG,
 };
 
 /// Startup configuration for the node.
@@ -58,7 +58,7 @@ impl NodeConfig {
         let mut net_addr = String::new();
         let mut rest_addr = String::new();
 
-        timeout(LOAD_ADDR_TIMEOUT_SECS, async {
+        timeout(LOAD_FILE_TIMEOUT_SECS, async {
             let net_addr_path = self.path.join(NET_ADDR_FILE);
             let rest_addr_path = self.path.join(REST_ADDR_FILE);
 
@@ -106,6 +106,7 @@ pub struct NodeMetaData {
 }
 
 impl NodeMetaData {
+    /// Creates a new [NodeMetaData].
     pub fn new(setup_path: &Path) -> Result<NodeMetaData> {
         // Read Ziggurat's configuration file.
         let path = setup_path.join(SETUP_CONFIG);

--- a/src/setup/constants.rs
+++ b/src/setup/constants.rs
@@ -33,8 +33,8 @@ pub const NET_ADDR_FILE: &str = "algod-listen.net";
 /// documentation](https://developer.algorand.org/docs/run-a-node/reference/config/).
 pub const REST_ADDR_FILE: &str = "algod.net";
 
-/// Timeout when waiting for loading of addresses.
-pub const LOAD_ADDR_TIMEOUT_SECS: Duration = Duration::from_secs(3);
+/// Timeout when waiting for loading of files.
+pub const LOAD_FILE_TIMEOUT_SECS: Duration = Duration::from_secs(3);
 
 /// Timeout when waiting for [Node](crate::setup::node::Node)'s start.
 pub const CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);

--- a/src/setup/kmd/config.rs
+++ b/src/setup/kmd/config.rs
@@ -1,0 +1,86 @@
+//! Utilities for kmd configuration.
+
+use std::{
+    net::SocketAddr,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+use anyhow::{anyhow, Result};
+use tokio::time::{sleep, timeout, Duration};
+
+use crate::setup::{
+    constants::LOAD_FILE_TIMEOUT_SECS,
+    kmd::constants::{KMD_DIR, REST_ADDR_FILE, TOKEN_FILE},
+};
+
+/// Startup configuration for the kmd daemon.
+#[derive(Debug, Clone, Default)]
+pub struct KmdConfig {
+    /// The kmd's directory of the running node.
+    pub path: PathBuf,
+    /// The REST API socket address of the kmd instance.
+    pub rest_api_addr: Option<SocketAddr>,
+    /// Security token needed for the REST API authentication.
+    pub token: String,
+}
+
+impl KmdConfig {
+    /// Creates a new [KmdConfig].
+    pub async fn new(node_path: &Path) -> anyhow::Result<Self> {
+        let mut token = String::new();
+
+        let path = node_path.join(KMD_DIR);
+        if !path.exists() {
+            return Err(anyhow!("couldn't find the {:?} directory", path));
+        }
+
+        timeout(LOAD_FILE_TIMEOUT_SECS, async {
+            let token_path = path.join(TOKEN_FILE);
+
+            token = KmdConfig::try_read_to_string(&token_path).await;
+        })
+        .await
+        .expect("couldn't fetch the kmd's token");
+
+        Ok(KmdConfig {
+            path,
+            rest_api_addr: None,
+            token,
+        })
+    }
+
+    /// Fetches the kmd's address.
+    pub async fn load_addr(&mut self) -> Result<()> {
+        let mut rest_addr = String::new();
+
+        timeout(LOAD_FILE_TIMEOUT_SECS, async {
+            let rest_addr_path = self.path.join(REST_ADDR_FILE);
+
+            rest_addr = KmdConfig::try_read_to_string(&rest_addr_path).await;
+        })
+        .await
+        .expect("couldn't fetch kmd's address");
+
+        self.rest_api_addr = Some(
+            SocketAddr::from_str(rest_addr.trim())
+                .expect("couldn't create the REST API socket address"),
+        );
+        Ok(())
+    }
+
+    /// Continuously try to read a string from a file.
+    async fn try_read_to_string(file_path: &Path) -> String {
+        loop {
+            match tokio::fs::read_to_string(&file_path).await {
+                Ok(content) => return content,
+                Err(e) => {
+                    if e.kind() == tokio::io::ErrorKind::NotFound {
+                        sleep(Duration::from_millis(100)).await;
+                        continue;
+                    }
+                }
+            };
+        }
+    }
+}

--- a/src/setup/kmd/constants.rs
+++ b/src/setup/kmd/constants.rs
@@ -1,0 +1,16 @@
+//! Useful setup constants.
+
+use tokio::time::Duration;
+
+/// Directory of the kmd instance.
+/// This directory is generated automatically within the node's directory when the node is created.
+pub const KMD_DIR: &str = "kmd-v0.5";
+
+/// Security token file needed for the REST API authentication.
+pub const TOKEN_FILE: &str = "kmd.token";
+
+/// The address on which the kmd instance listens for REST API calls.
+pub const REST_ADDR_FILE: &str = "kmd.net";
+
+/// Timeout when waiting for kmd instance to start responding.
+pub const CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);

--- a/src/setup/kmd/mod.rs
+++ b/src/setup/kmd/mod.rs
@@ -1,0 +1,156 @@
+//! The Key Management Daemon (kmd) is a low level wallet and key management
+//! tool. It works in conjunction with algod and goal to keep secrets safe.
+
+pub mod config;
+pub mod constants;
+
+use std::{
+    fs, io,
+    net::SocketAddr,
+    path::Path,
+    process::{Child, Command, Stdio},
+};
+
+use anyhow::anyhow;
+use tokio::{
+    io::AsyncWriteExt,
+    net::TcpStream,
+    time::{sleep, Duration},
+};
+
+use crate::setup::{
+    config::NodeMetaData,
+    constants::ALGORAND_SETUP_DIR,
+    get_algorand_work_path,
+    kmd::{
+        config::KmdConfig,
+        constants::{CONNECTION_TIMEOUT, REST_ADDR_FILE},
+    },
+    node::ChildExitCode,
+};
+
+pub struct KmdBuilder {
+    /// Node's process metadata read from Ziggurat configuration files.
+    meta: NodeMetaData,
+}
+
+impl KmdBuilder {
+    /// Creates a new [KmdBuilder].
+    pub fn new() -> anyhow::Result<Self> {
+        let setup_path = get_algorand_work_path()?.join(ALGORAND_SETUP_DIR);
+        let meta = NodeMetaData::new(&setup_path)?;
+
+        Ok(Self { meta })
+    }
+
+    /// Creates a [Kmd] according to configuration.
+    pub async fn build(&self, node_path: &Path) -> anyhow::Result<Kmd> {
+        if !node_path.exists() {
+            return Err(anyhow!("couldn't find the {:?} directory", node_path));
+        }
+
+        Ok(Kmd {
+            child: None,
+            conf: KmdConfig::new(node_path).await?,
+            meta: self.meta.clone(),
+        })
+    }
+}
+
+pub struct Kmd {
+    /// Kmd's process.
+    child: Option<Child>,
+    /// Kmd's startup configuration.
+    conf: KmdConfig,
+    /// Node's process metadata read from Ziggurat configuration files.
+    meta: NodeMetaData,
+}
+
+impl Kmd {
+    /// Creates a KmdBuilder.
+    pub fn builder() -> KmdBuilder {
+        KmdBuilder::new()
+            .map_err(|e| format!("unable to create a builder: {:?}", e))
+            .unwrap()
+    }
+
+    /// Waits the kmd instance to start responding.
+    async fn wait_for_start(addr: SocketAddr) {
+        tokio::time::timeout(CONNECTION_TIMEOUT, async {
+            const SLEEP: Duration = Duration::from_millis(100);
+
+            loop {
+                if let Ok(mut stream) = TcpStream::connect(addr).await {
+                    stream.shutdown().await.unwrap();
+                    break;
+                }
+
+                sleep(SLEEP).await;
+            }
+        })
+        .await
+        .unwrap();
+    }
+
+    /// Starts the kmd instance.
+    pub async fn start(&mut self) {
+        // Specify kmd's data path location with the `-d` option.
+        self.meta.start_args.push("-d".into());
+        self.meta.start_args.push(self.conf.path.clone().into());
+
+        let full_path = fs::canonicalize(self.meta.path.join("kmd")).unwrap();
+        let child = Command::new(full_path)
+            .current_dir(&self.meta.path)
+            .args(&self.meta.start_args)
+            .stdin(Stdio::null())
+            .spawn()
+            .expect("the kmd instance failed to start");
+        self.child = Some(child);
+
+        // Once the kmd instance is started, fetch its address.
+        self.conf
+            .load_addr()
+            .await
+            .expect("couldn't load the kmd's address");
+
+        Kmd::wait_for_start(self.conf.rest_api_addr.unwrap()).await;
+    }
+
+    /// Stops the kmd instance.
+    pub fn stop(&mut self) -> io::Result<ChildExitCode> {
+        // Cannot use 'mut self' due to the Drop impl.
+
+        // Remove the address file since the address may change if the kmd is restarted.
+        match fs::remove_file(self.conf.path.join(REST_ADDR_FILE)) {
+            Err(e) if e.kind() != io::ErrorKind::NotFound => panic!("unexpected error: {:?}", e),
+            _ => (),
+        };
+        self.conf.rest_api_addr = None;
+
+        let child = match self.child {
+            Some(ref mut child) => child,
+            None => return Ok(ChildExitCode::Success),
+        };
+
+        match child.try_wait()? {
+            None => child.kill()?,
+            Some(code) => return Ok(ChildExitCode::ErrorCode(code.code())),
+        }
+        let exit = child.wait()?;
+
+        match exit.code() {
+            None => Ok(ChildExitCode::Success),
+            Some(exit) if exit == 0 => Ok(ChildExitCode::Success),
+            Some(exit) => Ok(ChildExitCode::ErrorCode(Some(exit))),
+        }
+    }
+}
+
+impl Drop for Kmd {
+    fn drop(&mut self) {
+        // We should avoid a panic.
+        if let Err(e) = self.stop() {
+            eprintln!("Failed to stop the kmd instance: {}", e);
+        }
+    }
+}

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -3,6 +3,8 @@
 pub mod config;
 pub mod constants;
 #[allow(dead_code)]
+pub mod kmd;
+#[allow(dead_code)]
 pub mod node;
 
 use std::{io, path::PathBuf};

--- a/src/setup/node.rs
+++ b/src/setup/node.rs
@@ -62,7 +62,7 @@ impl NodeBuilder {
         copy_options.overwrite = true;
         dir::copy(&source, target, &copy_options)?;
 
-        // TODO(Rqnsom) configure the node.
+        // Note: we would implement dynamic node configuration here if the need occurs.
 
         let mut conf = self.conf.clone();
         conf.path = target.to_path_buf();

--- a/src/tests/conformance/post_handshake/cmd/mod.rs
+++ b/src/tests/conformance/post_handshake/cmd/mod.rs
@@ -1,0 +1,1 @@
+mod transaction;

--- a/src/tests/conformance/post_handshake/cmd/transaction.rs
+++ b/src/tests/conformance/post_handshake/cmd/transaction.rs
@@ -1,0 +1,36 @@
+use tempfile::TempDir;
+
+use crate::setup::{kmd::Kmd, node::Node};
+
+#[tokio::test]
+#[allow(non_snake_case)]
+async fn c012_TXN_submit_txn_and_expect_to_receive_it() {
+    // ZG-CONFORMANCE-012
+    // TODO: write a description in the SPEC doc (once all is done here)
+
+    // Spin up a node instance.
+    let target = TempDir::new().expect("couldn't create a temporary directory");
+    let mut node = Node::builder()
+        .build(target.path())
+        .expect("unable to build the node");
+    node.start().await;
+
+    let mut kmd = Kmd::builder()
+        .build(target.path())
+        .await
+        .expect("unable to build the kmd instance");
+    kmd.start().await;
+
+    // TODO(Rqnsom):
+    // 1. add two synthetic_node nodes
+    // 2. prepare a transaction via kmd V1 REST API
+    // 3. the synthetic_node_tx node submits a txn to the node
+    // 4. the synthetic_node_rx node expects that same txn from the node
+
+    // temp solution to check all is running well (manual check).
+    tokio::time::sleep(tokio::time::Duration::from_secs(300)).await;
+
+    // Gracefully shut down the nodes.
+    kmd.stop().expect("unable to stop the kmd instance");
+    node.stop().expect("unable to stop the node");
+}

--- a/src/tests/conformance/post_handshake/mod.rs
+++ b/src/tests/conformance/post_handshake/mod.rs
@@ -1,4 +1,5 @@
 mod broadcast;
+mod cmd;
 mod msg_of_interest;
 mod net_prio_response;
 mod query;


### PR DESCRIPTION
The solution for the `kmd` is based on setup/node solution, so there's not much new original content here.

The initial test provided here in `transaction.rs` contains a full plan for that test

commits:
```
    feat: add initial version of transaction test

    - current test just starts the node and the kmd instance
    - includes a TODO list with the plan for the test (coming soon)
```
```
    feat: introduce start/stop support for kmd

    The Key Management Daemon (kmd) is a low level wallet and key management
    tool. It works in conjunction with algod and goal to keep secrets safe.
```
```
    chore: rename node's setup const
```