### PR TITLE
feat(kmd): add REST API support for /v1/wallet/init

### DIFF
--- a/src/setup/kmd/mod.rs
+++ b/src/setup/kmd/mod.rs
@@ -26,7 +26,10 @@ use crate::setup::{
     kmd::{
         config::KmdConfig,
         constants::{CONNECTION_TIMEOUT, REST_ADDR_FILE},
-        rest_api::{client::ClientV1, message::ListWalletsResponse},
+        rest_api::{
+            client::ClientV1,
+            message::{InitWalletHandleResponse, ListWalletsResponse},
+        },
     },
     node::ChildExitCode,
 };
@@ -162,6 +165,21 @@ impl Kmd {
     pub async fn get_wallets(&mut self) -> anyhow::Result<ListWalletsResponse> {
         if let Some(rest_client) = &self.rest_client {
             return rest_client.get_wallets().await;
+        }
+
+        Err(anyhow!("the kmd instance is not started"))
+    }
+
+    /// Unlock the wallet and return a wallet handle token that can be used for subsequent operations.
+    pub async fn get_wallet_handle_token(
+        &mut self,
+        wallet_id: String,
+        wallet_password: String,
+    ) -> anyhow::Result<InitWalletHandleResponse> {
+        if let Some(rest_client) = &self.rest_client {
+            return rest_client
+                .get_wallet_handle_token(wallet_id, wallet_password)
+                .await;
         }
 
         Err(anyhow!("the kmd instance is not started"))

--- a/src/setup/kmd/rest_api/client.rs
+++ b/src/setup/kmd/rest_api/client.rs
@@ -3,7 +3,9 @@
 //! The kmd daemons provide their API specifications here:
 //! https://developer.algorand.org/docs/rest-apis/kmd/
 
-use crate::setup::kmd::rest_api::message::ListWalletsResponse;
+use crate::setup::kmd::rest_api::message::{
+    InitWalletHandleRequest, InitWalletHandleResponse, ListWalletsResponse,
+};
 
 const API_HEADER_TOKEN: &str = "X-KMD-API-Token";
 const API_HEADER_ACCEPT_JSON: &str = "application/json";
@@ -39,5 +41,38 @@ impl ClientV1 {
             .json()
             .await
             .map_err(|e| anyhow::anyhow!("couldn't get the wallets: {e}"))
+    }
+
+    /// Unlock the wallet and return a wallet handle token that can be used for subsequent operations.
+    ///
+    /// These tokens expire periodically and must be renewed. You can POST the token to
+    /// /v1/wallet/info to see how much time remains until expiration, and renew it with
+    /// /v1/wallet/renew. When you're done, you can invalidate the token with /v1/wallet/release.
+    pub async fn get_wallet_handle_token(
+        &self,
+        wallet_id: String,
+        wallet_password: String,
+    ) -> anyhow::Result<InitWalletHandleResponse> {
+        let req = InitWalletHandleRequest {
+            wallet_id,
+            wallet_password,
+        };
+
+        self.http_client
+            .post(&format!("{}v1/wallet/init", self.address))
+            .header(API_HEADER_TOKEN, &self.token)
+            .header(reqwest::header::ACCEPT, API_HEADER_ACCEPT_JSON)
+            .json(&req)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "couldn't initialize the wallet (id: {}: {e})",
+                    req.wallet_id
+                )
+            })
     }
 }

--- a/src/setup/kmd/rest_api/message.rs
+++ b/src/setup/kmd/rest_api/message.rs
@@ -3,7 +3,7 @@
 //! The kmd daemons provide their API specifications here:
 //! https://developer.algorand.org/docs/rest-apis/kmd/
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// APIV1Wallet is the API's representation of a wallet.
 #[derive(Debug, Deserialize)]
@@ -21,4 +21,17 @@ pub struct ApiV1Wallet {
 pub struct ListWalletsResponse {
     #[serde(default)]
     pub wallets: Vec<ApiV1Wallet>,
+}
+
+/// InitWalletHandleRequest is the request for `POST /v1/wallet/init`.
+#[derive(Serialize)]
+pub(super) struct InitWalletHandleRequest {
+    pub wallet_id: String,
+    pub wallet_password: String,
+}
+
+/// InitWalletHandleResponse is the response to `POST /v1/wallet/init`.
+#[derive(Debug, Deserialize)]
+pub struct InitWalletHandleResponse {
+    pub wallet_handle_token: String,
 }

--- a/src/tests/conformance/post_handshake/cmd/transaction.rs
+++ b/src/tests/conformance/post_handshake/cmd/transaction.rs
@@ -22,11 +22,22 @@ async fn c012_TXN_submit_txn_and_expect_to_receive_it() {
     kmd.start().await;
 
     let wallets = kmd.get_wallets().await.expect("couldn't get the wallets");
-    println!("a temporary log with wallets: {:?}", wallets);
+    let wallet_id = wallets
+        .wallets
+        .into_iter()
+        .find(|wallet| wallet.name == "unencrypted-default-wallet")
+        .expect("couldn't find an unencrypted default wallet")
+        .id;
+
+    let init_wallet_rsp = kmd.get_wallet_handle_token(wallet_id, "".to_string()).await;
+    println!(
+        "a temporary log with init_wallet_rsp: {:?}",
+        init_wallet_rsp
+    );
 
     // TODO(Rqnsom):
     // 1. add two synthetic_node nodes
-    // 2. prepare a transaction via kmd V1 REST API (ongoing)
+    // 2. prepare a transaction via kmd V1 REST API (ongoing...)
     // 3. the synthetic_node_tx node submits a txn to the node
     // 4. the synthetic_node_rx node expects that same txn from the node
 


### PR DESCRIPTION
Unlock the wallet and return a wallet handle token that can be used for subsequent operations. These tokens expire periodically and must be renewed. You can POST the token to /v1/wallet/info to see how much time remains until expiration, and renew it with /v1/wallet/renew. When you're done, you can invalidate the token with /v1/wallet/release.