### PR TITLE
refactor: break out common code from txn test

### DIFF
--- a/src/protocol/codecs/msgpack.rs
+++ b/src/protocol/codecs/msgpack.rs
@@ -1,6 +1,7 @@
 //! Message pack deserializer for algod messages.
 
 use std::{
+    convert::From,
     fmt::{self, Debug, Display, Formatter},
     str,
 };
@@ -289,7 +290,7 @@ pub struct Transaction {
 
     /// The human-readable string that identifies the network for the transaction. The genesis ID is
     /// found in the genesis block.
-    #[serde(rename = "gen")]
+    #[serde(default, rename = "gen")]
     pub genesis_id: String,
 
     /// The group specifies that the transaction is part of a group and, if so, specifies the hash of
@@ -311,7 +312,7 @@ pub struct Transaction {
     #[serde(rename = "lx", default)]
     pub lease: Option<HashDigest>,
 
-    /// Any data up to 1000 bytes.
+    /// Any data up to 1024 bytes.
     #[serde(with = "serde_bytes", default)]
     pub note: Vec<u8>,
 
@@ -441,6 +442,15 @@ impl Display for HashDigest {
 impl Debug for HashDigest {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{}", BASE32_NOPAD.encode(&self.0))
+    }
+}
+
+impl From<&Vec<u8>> for HashDigest {
+    fn from(data: &Vec<u8>) -> Self {
+        let hashed = sha2::Sha512_256::digest(data);
+        let mut hash = [0; 32];
+        hash.copy_from_slice(&hashed);
+        HashDigest(hash)
     }
 }
 

--- a/src/tests/conformance/post_handshake/cmd/mod.rs
+++ b/src/tests/conformance/post_handshake/cmd/mod.rs
@@ -1,1 +1,81 @@
+//! Test suite for command messages - which do not generate a response from the node.
+
 mod transaction;
+
+use std::net::SocketAddr;
+
+use crate::{
+    protocol::codecs::{
+        msgpack::{Address, Transaction},
+        tagmsg::Tag,
+    },
+    setup::{
+        kmd::Kmd,
+        node::{rest_api::message::TransactionParams, Node},
+    },
+    tools::synthetic_node::{SyntheticNode, SyntheticNodeBuilder},
+};
+
+async fn get_handshaked_synth_node(net_addr: SocketAddr) -> SyntheticNode {
+    // Create a synthetic node and enable handshaking.
+    let synthetic_node = SyntheticNodeBuilder::default()
+        .build()
+        .await
+        .expect("unable to build a synthetic node");
+
+    // Connect to the node and initiate the handshake.
+    synthetic_node
+        .connect(net_addr)
+        .await
+        .expect("unable to connect");
+
+    synthetic_node
+}
+
+async fn get_wallet_token(kmd: &mut Kmd) -> String {
+    let wallets = kmd.get_wallets().await.expect("couldn't get the wallets");
+
+    let wallet_id = wallets
+        .wallets
+        .into_iter()
+        .find(|wallet| wallet.name == "unencrypted-default-wallet")
+        .expect("couldn't find an unencrypted default wallet")
+        .id;
+
+    kmd.get_wallet_handle_token(wallet_id, "".to_string())
+        .await
+        .expect("couldn't get the wallet token")
+        .wallet_handle_token
+}
+
+async fn get_txn_params(node: &mut Node) -> TransactionParams {
+    node.rest_client()
+        .expect("couldn't get the REST client")
+        .get_transaction_params()
+        .await
+        .expect("couldn't get the transaction parameters")
+}
+
+async fn get_pub_key_addr(kmd: &mut Kmd, wallet_token: String) -> Address {
+    let pub_key = kmd
+        .get_keys(wallet_token)
+        .await
+        .expect("couldn't get the wallet keys")
+        .addresses
+        .pop()
+        .expect("couldn't find any public keys in the wallet");
+
+    Address::from_string(&pub_key).expect("couldn't convert public key to address")
+}
+
+async fn get_signed_tagged_txn(kmd: &mut Kmd, wallet_token: String, txn: &Transaction) -> Vec<u8> {
+    let mut signed_txn = kmd
+        .sign_transaction(wallet_token, "".to_string(), txn)
+        .await
+        .expect("couldn't sign the transaction")
+        .signed_transaction;
+
+    let mut tagged_msg = Tag::get_tag_str(&Tag::Txn).as_bytes().to_vec();
+    tagged_msg.append(&mut signed_txn);
+    tagged_msg
+}


### PR DESCRIPTION
Some refactor work needed for msg_digest_skip test

Also in another commit:
- `impl From<&Vec<u8>> for HashDigest`