### PR TITLE
feat: higher/lower priority messages load test

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ These results were obtained by running the test suite against [Algorand v3.12.2-
 ### Performance
 
 |             Test Case             | Algod  | Additional Information                                                      |
-| :-------------------------------: | :----: | :-------------------------------------------------------------------------- |
+|:---------------------------------:| :----: | :-------------------------------------------------------------------------- |
 | [001](SPEC.md#ZG-PERFORMANCE-001) |   ✓    |                                                                             |
-
+| [002](SPEC.md#ZG-PERFORMANCE-002) |   ✓    |                                                                             |
 ### Resistance
 
 |             Test Case             | Algod  | Additional Information                                                      |

--- a/SPEC.md
+++ b/SPEC.md
@@ -236,6 +236,24 @@ _TODO: Investigate more REST API calls and possibly include above._
     Results should be introspected manually to check the node's health and responsiveness
     (latency, throughput) when requesting block data.
 
+### ZG-PERFORMANCE-002
+
+    The node behaves as expected under load when some peers are sending higher priority messages and some other peer 
+    is trying to request blocks with certificates (that are lower priority messages).
+
+    Normal peer:
+    <>
+    In loop:
+        -> UniEnsBlockReq
+        <- TopicMsgResp
+
+    High priority peers (potential malicious ones):
+        <>
+    In loop:
+        -> MsgOfInterest
+
+    Results should be introspected manually to check the normal peer responsiveness (latency, throughput) when requesting block data.
+
 ## Resistance
 
 ### ZG-RESISTANCE-001

--- a/src/tests/performance/mod.rs
+++ b/src/tests/performance/mod.rs
@@ -1,1 +1,2 @@
 mod get_blocks;
+mod prio_test;

--- a/src/tests/performance/prio_test.rs
+++ b/src/tests/performance/prio_test.rs
@@ -21,9 +21,8 @@ use crate::{
     setup::node::Node,
     tools::{
         constants::{
-            ERR_BIND_TO_SOCKET_FAILED, ERR_NET_ADDR_NOT_FOUND, ERR_NODE_BUILD_FAILED,
-            ERR_NODE_CONNECTION_FAILED, ERR_NODE_UNABLE_TO_STOP, ERR_SEND_MESSAGE_FAILED,
-            ERR_SYNTH_NODE_BUILD_FAILED, ERR_TEMPDIR_CREATION_FAILED,
+            ERR_NODE_ADDR, ERR_NODE_BUILD, ERR_NODE_CONNECT, ERR_NODE_STOP, ERR_SOCKET_BIND,
+            ERR_SYNTH_BUILD, ERR_SYNTH_UNICAST, ERR_TEMPDIR_NEW,
         },
         ips::IPS,
         metrics::{
@@ -103,12 +102,12 @@ const RESPONSE_TIMEOUT: Duration = Duration::from_secs(3);
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[allow(non_snake_case)]
 async fn p002_t1_PRIO_MSG_latency() {
-    // ZG-PERFORMANCE-002, Block getting latency while malicious nodes send higher priority msgs
+    // ZG-PERFORMANCE-002, Getting low prio meesages while other nodes send higher priority msgs
     //
     // We test the overall performance of a node's get blocks (with certs) latency while other
-    // malicious nodes send higher priority messages.
+    // other nodes send higher priority messages.
     //
-    // Test should be inspected manually to check how other malicious nodes affect the latency of
+    // Test should be inspected manually to check how other nodes affect the latency of
     // the node under test.
     //
     // Sample results:
@@ -132,27 +131,25 @@ async fn p002_t1_PRIO_MSG_latency() {
     // *NOTE* run with `cargo test --release  tests::performance::prio -- --nocapture`
     // Before running test generate dummy devices with different ips using toos/ips.py
 
-    let h_prio_peers = vec![1, 50, 100, 200, 300, 400, 799];
+    let h_prio_peer_set = vec![1, 50, 100, 200, 300, 400, 799];
     let l_prio_peers = 1;
 
     let mut table = RequestsTable::default();
 
-    for hp_peer_iter_cnt in h_prio_peers {
-        // synth_count malicious tasks plus one normal synth_node
-        let barrier = Arc::new(Barrier::new(hp_peer_iter_cnt + 1));
+    for h_prio_peers in h_prio_peer_set {
+        let total_peers = l_prio_peers + h_prio_peers;
+        let barrier = Arc::new(Barrier::new(total_peers));
 
-        let target = TempDir::new().expect(ERR_TEMPDIR_CREATION_FAILED);
-        let mut node = Node::builder()
-            .build(target.path())
-            .expect(ERR_NODE_BUILD_FAILED);
+        let target = TempDir::new().expect(ERR_TEMPDIR_NEW);
+        let mut node = Node::builder().build(target.path()).expect(ERR_NODE_BUILD);
         node.start().await;
 
-        let node_addr = node.net_addr().expect(ERR_NET_ADDR_NOT_FOUND);
+        let node_addr = node.net_addr().expect(ERR_NODE_ADDR);
 
-        let mut synth_sockets = Vec::with_capacity(hp_peer_iter_cnt + 1);
+        let mut synth_sockets = Vec::with_capacity(total_peers);
         let mut ips = IPS.to_vec();
 
-        for _ in 0..hp_peer_iter_cnt + 1 {
+        for _ in 0..total_peers {
             // If there is address for our thread in the pool we can use it.
             // Otherwise we'll not set bound_addr and use local IP addr (127.0.0.1).
             let ip = ips.pop().unwrap_or("127.0.0.1");
@@ -164,7 +161,7 @@ async fn p002_t1_PRIO_MSG_latency() {
             socket.set_reuseaddr(true).unwrap();
             socket.set_reuseport(true).unwrap();
 
-            socket.bind(ip).expect(ERR_BIND_TO_SOCKET_FAILED);
+            socket.bind(ip).expect(ERR_SOCKET_BIND);
             synth_sockets.push(socket);
         }
 
@@ -177,7 +174,7 @@ async fn p002_t1_PRIO_MSG_latency() {
         let test_start = tokio::time::Instant::now();
 
         let arc_barrier = barrier.clone();
-        synth_handles.spawn(simulate_normal_peer(
+        synth_handles.spawn(simulate_low_priority_peer(
             node_addr,
             synth_sockets.pop().unwrap(),
             arc_barrier,
@@ -185,7 +182,7 @@ async fn p002_t1_PRIO_MSG_latency() {
 
         for socket in synth_sockets {
             let arc_barrier = barrier.clone();
-            synth_handles.spawn(simulate_malicious_peer(node_addr, socket, arc_barrier));
+            synth_handles.spawn(simulate_high_priority_peer(node_addr, socket, arc_barrier));
         }
 
         // wait for peers to complete
@@ -198,8 +195,8 @@ async fn p002_t1_PRIO_MSG_latency() {
             if latencies.entries() >= 1 {
                 // add stats to table display
                 table.add_row(RequestStats::new(
-                    l_prio_peers, // only one normal peer
-                    hp_peer_iter_cnt as u16,
+                    l_prio_peers as u16, // only one normal peer
+                    h_prio_peers as u16,
                     REQUESTS,
                     latencies,
                     time_taken_secs,
@@ -207,7 +204,7 @@ async fn p002_t1_PRIO_MSG_latency() {
             }
         }
 
-        node.stop().expect(ERR_NODE_UNABLE_TO_STOP);
+        node.stop().expect(ERR_NODE_STOP);
     }
 
     // Display results table
@@ -215,7 +212,7 @@ async fn p002_t1_PRIO_MSG_latency() {
 }
 
 const ROUND_KEY: Round = 1;
-async fn simulate_normal_peer(
+async fn simulate_low_priority_peer(
     node_addr: SocketAddr,
     socket: TcpSocket,
     start_barrier: Arc<Barrier>,
@@ -223,13 +220,13 @@ async fn simulate_normal_peer(
     let mut synth_node = SyntheticNodeBuilder::default()
         .build()
         .await
-        .expect(ERR_SYNTH_NODE_BUILD_FAILED);
+        .expect(ERR_SYNTH_BUILD);
 
     // Establish peer connection
     synth_node
         .connect_from(node_addr, socket)
         .await
-        .expect(ERR_NODE_CONNECTION_FAILED);
+        .expect(ERR_NODE_CONNECT);
 
     // Wait for all peers to connect
     start_barrier.wait().await;
@@ -248,7 +245,7 @@ async fn simulate_normal_peer(
 
         synth_node
             .unicast(node_addr, message)
-            .expect(ERR_SEND_MESSAGE_FAILED);
+            .expect(ERR_SYNTH_UNICAST);
 
         let now = Instant::now();
 
@@ -271,7 +268,7 @@ async fn simulate_normal_peer(
     synth_node.shut_down().await
 }
 
-async fn simulate_malicious_peer(
+async fn simulate_high_priority_peer(
     node_addr: SocketAddr,
     socket: TcpSocket,
     start_barrier: Arc<Barrier>,
@@ -279,13 +276,13 @@ async fn simulate_malicious_peer(
     let mut synth_node = SyntheticNodeBuilder::default()
         .build()
         .await
-        .expect(ERR_SYNTH_NODE_BUILD_FAILED);
+        .expect(ERR_SYNTH_BUILD);
 
     // Establish peer connection
     synth_node
         .connect_from(node_addr, socket)
         .await
-        .expect(ERR_NODE_CONNECTION_FAILED);
+        .expect(ERR_NODE_CONNECT);
 
     // Wait for all peers to start
     start_barrier.wait().await;
@@ -317,7 +314,7 @@ async fn simulate_malicious_peer(
 
         synth_node
             .unicast(node_addr, message)
-            .expect(ERR_SEND_MESSAGE_FAILED);
+            .expect(ERR_SYNTH_UNICAST);
 
         // Just check if there is anything to read in the incoming queue. If so, read and
         // discard it. We don't care about the response.

--- a/src/tests/performance/prio_test.rs
+++ b/src/tests/performance/prio_test.rs
@@ -1,0 +1,313 @@
+use std::{
+    collections::HashSet,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    str::FromStr,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use histogram::Histogram;
+use tabled::{Table, Tabled};
+use tempfile::TempDir;
+use tokio::{net::TcpSocket, sync::Barrier, task::JoinSet, time::timeout};
+
+use crate::{
+    protocol::codecs::{
+        msgpack::Round,
+        payload::Payload,
+        tagmsg::Tag,
+        topic::{MsgOfInterest, TopicMsgResp, UniEnsBlockReq, UniEnsBlockReqType},
+    },
+    setup::node::Node,
+    tools::{
+        ips::IPS,
+        metrics::{
+            recorder::TestMetrics,
+            tables::{duration_as_ms, fmt_table, table_float_display},
+        },
+        synthetic_node::SyntheticNodeBuilder,
+    },
+};
+
+#[derive(Default)]
+pub struct RequestsTable {
+    rows: Vec<RequestStats>,
+}
+
+#[derive(Tabled, Default, Debug, Clone)]
+pub struct RequestStats {
+    #[tabled(rename = " peers ")]
+    peers: u16,
+    #[tabled(rename = " malicious peers ")]
+    mpeers: u16,
+    #[tabled(rename = " requests ")]
+    requests: u16,
+    #[tabled(rename = " min (ms) ")]
+    latency_min: u16,
+    #[tabled(rename = " max (ms) ")]
+    latency_max: u16,
+    #[tabled(rename = " std dev (ms) ")]
+    latency_std_dev: u16,
+    #[tabled(rename = " completion % ")]
+    #[tabled(display_with = "table_float_display")]
+    completion: f64,
+    #[tabled(rename = " time (s) ")]
+    #[tabled(display_with = "table_float_display")]
+    time: f64,
+}
+
+impl RequestStats {
+    pub fn new(peers: u16, mpeers: u16, requests: u16, latencies: Histogram, time: f64) -> Self {
+        Self {
+            peers,
+            mpeers,
+            requests,
+            completion: (latencies.entries() as f64) / (peers as f64 * requests as f64) * 100.00,
+            latency_min: latencies.minimum().unwrap() as u16,
+            latency_max: latencies.maximum().unwrap() as u16,
+            latency_std_dev: latencies.stddev().unwrap() as u16,
+            time,
+        }
+    }
+}
+
+impl RequestsTable {
+    pub fn add_row(&mut self, row: RequestStats) {
+        self.rows.push(row);
+    }
+}
+
+impl std::fmt::Display for RequestsTable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&fmt_table(Table::new(&self.rows)))
+    }
+}
+
+const METRIC_LATENCY: &str = "prio_test_latency";
+// number of requests to send per peer
+const REQUESTS: u16 = 300;
+const RESPONSE_TIMEOUT: Duration = Duration::from_secs(3);
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+#[allow(non_snake_case)]
+async fn p002_t1_PRIO_MSG_latency() {
+    // ZG-PERFORMANCE-002, Block getting latency while malicious nodes send higher priority msgs
+    //
+    // We test the overall performance of a node's get blocks (with certs) latency while other
+    // malicious nodes send higher priority messages.
+    //
+    // Test should be inspected manually to check how other malicious nodes affect the latency of
+    // the node under test.
+    //
+    // Sample results:
+    // ┌─────────┬───────────────────┬────────────┬────────────┬────────────┬────────────────┬────────────────┬────────────┐
+    // │  peers  │  malicious peers  │  requests  │  min (ms)  │  max (ms)  │  std dev (ms)  │  completion %  │  time (s)  │
+    // ├─────────┼───────────────────┼────────────┼────────────┼────────────┼────────────────┼────────────────┼────────────┤
+    // │       1 │                 1 │        300 │          1 │          1 │              0 │         100.00 │       0.41 │
+    // ├─────────┼───────────────────┼────────────┼────────────┼────────────┼────────────────┼────────────────┼────────────┤
+    // │       1 │                50 │        300 │          1 │          2 │              1 │         100.00 │       0.51 │
+    // ├─────────┼───────────────────┼────────────┼────────────┼────────────┼────────────────┼────────────────┼────────────┤
+    // │       1 │               100 │        300 │          1 │          3 │              1 │         100.00 │       0.64 │
+    // ├─────────┼───────────────────┼────────────┼────────────┼────────────┼────────────────┼────────────────┼────────────┤
+    // │       1 │               200 │        300 │          1 │          5 │              1 │         100.00 │       0.62 │
+    // ├─────────┼───────────────────┼────────────┼────────────┼────────────┼────────────────┼────────────────┼────────────┤
+    // │       1 │               300 │        300 │          1 │         14 │              2 │         100.00 │       0.80 │
+    // ├─────────┼───────────────────┼────────────┼────────────┼────────────┼────────────────┼────────────────┼────────────┤
+    // │       1 │               400 │        300 │          1 │          9 │              1 │         100.00 │       0.82 │
+    // └─────────┴───────────────────┴────────────┴────────────┴────────────┴────────────────┴────────────────┴────────────┘
+    // *NOTE* run with `cargo test --release  tests::performance::prio -- --nocapture`
+    // Before running test generate dummy devices with different ips using toos/ips.py
+
+    let synth_counts = vec![1, 50, 100, 200, 300, 400];
+
+    let mut table = RequestsTable::default();
+
+    for synth_count in synth_counts {
+        // synth_count malicious tasks plus one normal synth_node
+        let barrier = Arc::new(Barrier::new(synth_count + 1));
+
+        let target = TempDir::new().expect("couldn't create a temporary directory");
+        let mut node = Node::builder()
+            .build(target.path())
+            .expect("unable to build the node");
+        node.start().await;
+
+        let node_addr = node.net_addr().expect("network address not found");
+
+        let mut synth_sockets = Vec::with_capacity(synth_count + 1);
+        let mut ips = IPS.to_vec();
+
+        for _ in 0..synth_count + 1 {
+            // If there is address for our thread in the pool we can use it.
+            // Otherwise we'll not set bound_addr and use local IP addr (127.0.0.1).
+            let ip = ips.pop().unwrap_or("127.0.0.1");
+
+            let ip = SocketAddr::new(IpAddr::V4(Ipv4Addr::from_str(ip).unwrap()), 0);
+            let socket = TcpSocket::new_v4().unwrap();
+
+            // Make sure we can reuse the address and port
+            socket.set_reuseaddr(true).unwrap();
+            socket.set_reuseport(true).unwrap();
+
+            socket.bind(ip).expect("unable to bind to socket");
+            synth_sockets.push(socket);
+        }
+
+        // setup metrics recorder
+        let test_metrics = TestMetrics::default();
+        // clear metrics and register metrics
+        metrics::register_histogram!(METRIC_LATENCY);
+
+        let mut synth_handles = JoinSet::new();
+        let test_start = tokio::time::Instant::now();
+
+        let arc_barrier = barrier.clone();
+        synth_handles.spawn(simulate_normal_peer(
+            node_addr,
+            synth_sockets.pop().unwrap(),
+            arc_barrier,
+        ));
+
+        for socket in synth_sockets {
+            let arc_barrier = barrier.clone();
+            synth_handles.spawn(simulate_malicious_peer(node_addr, socket, arc_barrier));
+        }
+
+        // wait for peers to complete
+        while (synth_handles.join_next().await).is_some() {}
+
+        let time_taken_secs = test_start.elapsed().as_secs_f64();
+
+        let snapshot = test_metrics.take_snapshot();
+        if let Some(latencies) = snapshot.construct_histogram(METRIC_LATENCY) {
+            if latencies.entries() >= 1 {
+                // add stats to table display
+                table.add_row(RequestStats::new(
+                    1_u16, // only one normal peer
+                    synth_count as u16,
+                    REQUESTS,
+                    latencies,
+                    time_taken_secs,
+                ));
+            }
+        }
+
+        node.stop().expect("unable to stop the node");
+    }
+
+    // Display results table
+    println!("\r\n{}", table);
+}
+
+const ROUND_KEY: Round = 1;
+#[allow(unused_must_use)] // just for result of the timeout
+async fn simulate_normal_peer(
+    node_addr: SocketAddr,
+    socket: TcpSocket,
+    start_barrier: Arc<Barrier>,
+) {
+    let mut synth_node = SyntheticNodeBuilder::default()
+        .build()
+        .await
+        .expect("unable to build a synthetic node");
+
+    // Establish peer connection
+    synth_node
+        .connect_from(node_addr, socket)
+        .await
+        .expect("unable to connect to node");
+
+    // Wait for all peers to connect
+    start_barrier.wait().await;
+
+    for i in 0..REQUESTS {
+        let message = Payload::UniEnsBlockReq(UniEnsBlockReq {
+            data_type: UniEnsBlockReqType::BlockAndCert,
+            round_key: ROUND_KEY,
+            nonce: i as u64,
+        });
+
+        // Query transaction via peer protocol.
+        if !synth_node.is_connected(node_addr) {
+            break;
+        }
+
+        synth_node
+            .unicast(node_addr, message)
+            .expect("unable to send message");
+
+        let now = Instant::now();
+
+        // We can safely drop the result here because we don't care about it - if the message is
+        // received and it's our response we simply register it for histogram and break the loop.
+        // In every other case we simply move out and go to another request iteration.
+        timeout(RESPONSE_TIMEOUT, async {
+            loop {
+                let m = synth_node.recv_message().await;
+                if matches!(&m.1, Payload::TopicMsgResp(TopicMsgResp::UniEnsBlockRsp(rsp))
+                     if rsp.block.is_some() && rsp.block.as_ref().unwrap().round == ROUND_KEY && rsp.cert.is_some()) {
+                    metrics::histogram!(METRIC_LATENCY, duration_as_ms(now.elapsed()));
+                    break;
+                }
+            }
+        }).await;
+    }
+
+    synth_node.shut_down().await
+}
+
+async fn simulate_malicious_peer(
+    node_addr: SocketAddr,
+    socket: TcpSocket,
+    start_barrier: Arc<Barrier>,
+) {
+    let mut synth_node = SyntheticNodeBuilder::default()
+        .build()
+        .await
+        .expect("unable to build a synthetic node");
+
+    // Establish peer connection
+    synth_node
+        .connect_from(node_addr, socket)
+        .await
+        .expect("unable to connect to node");
+
+    // Wait for all peers to start
+    start_barrier.wait().await;
+
+    for _ in 0..REQUESTS {
+        // Send a MsgOfInterest message with all expected tags included.
+        let tags = HashSet::from([
+            Tag::ProposalPayload,
+            Tag::AgreementVote,
+            Tag::MsgOfInterest,
+            Tag::MsgDigestSkip,
+            Tag::NetPrioResponse,
+            Tag::Ping,
+            Tag::PingReply,
+            Tag::ProposalPayload,
+            Tag::StateProofSig,
+            Tag::TopicMsgResp,
+            Tag::Txn,
+            Tag::UniEnsBlockReq,
+            Tag::VoteBundle,
+        ]);
+        let message = Payload::MsgOfInterest(MsgOfInterest { tags });
+
+        if !synth_node.is_connected(node_addr) {
+            break;
+        }
+
+        synth_node
+            .unicast(node_addr, message)
+            .expect("unable to send message");
+
+        // Just check if there is anything to read in the incoming queue. If so, read and
+        // discard it. We don't care about the response.
+        let _ = synth_node
+            .recv_message_timeout(Duration::from_micros(10))
+            .await;
+    }
+
+    synth_node.shut_down().await
+}

--- a/src/tools/constants.rs
+++ b/src/tools/constants.rs
@@ -9,26 +9,28 @@ pub const CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);
 pub const EXPECT_MSG_TIMEOUT: Duration = Duration::from_secs(10);
 
 // Below common error constants and messages to be used across the project.
-/// Error message when binding to specified socket fails.
-pub const ERR_BIND_TO_SOCKET_FAILED: &str = "unable to bind to socket";
+// The main rule to create const names is: ERR_<WHO>_<FUNCTION_NAME>
 
-/// Error message when node network address is not found.
-pub const ERR_NET_ADDR_NOT_FOUND: &str = "network address not found";
+/// Error message when binding to specified socket fails.
+pub const ERR_SOCKET_BIND: &str = "unable to bind to socket";
+
+/// Error message when the node's network address is not found.
+pub const ERR_NODE_ADDR: &str = "network address not found";
 
 /// Error message for a failed connection.
-pub const ERR_NODE_CONNECTION_FAILED: &str = "unable to connect to the node";
+pub const ERR_NODE_CONNECT: &str = "unable to connect to the node";
 
 /// Error message when building a node fails.
-pub const ERR_NODE_BUILD_FAILED: &str = "unable to build the node";
+pub const ERR_NODE_BUILD: &str = "unable to build the node";
 
 /// Error message when a node fails to stop.
-pub const ERR_NODE_UNABLE_TO_STOP: &str = "unable to stop the node";
+pub const ERR_NODE_STOP: &str = "unable to stop the node";
 
 /// Error message when sending message fails.
-pub const ERR_SEND_MESSAGE_FAILED: &str = "unable to send message";
+pub const ERR_SYNTH_UNICAST: &str = "unable to send a message";
 
 /// Error message when synthetic node creation fails.
-pub const ERR_SYNTH_NODE_BUILD_FAILED: &str = "unable to build a synthetic node";
+pub const ERR_SYNTH_BUILD: &str = "unable to build a synthetic node";
 
 /// Error message when temporary directory creation fails.
-pub const ERR_TEMPDIR_CREATION_FAILED: &str = "couldn't create a temporary directory";
+pub const ERR_TEMPDIR_NEW: &str = "couldn't create a temporary directory";

--- a/src/tools/constants.rs
+++ b/src/tools/constants.rs
@@ -7,3 +7,28 @@ pub const CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Timeout when waiting for an expected message or a change in the node's state.
 pub const EXPECT_MSG_TIMEOUT: Duration = Duration::from_secs(10);
+
+// Below common error constants and messages to be used across the project.
+/// Error message when binding to specified socket fails.
+pub const ERR_BIND_TO_SOCKET_FAILED: &str = "unable to bind to socket";
+
+/// Error message when node network address is not found.
+pub const ERR_NET_ADDR_NOT_FOUND: &str = "network address not found";
+
+/// Error message for a failed connection.
+pub const ERR_NODE_CONNECTION_FAILED: &str = "unable to connect to the node";
+
+/// Error message when building a node fails.
+pub const ERR_NODE_BUILD_FAILED: &str = "unable to build the node";
+
+/// Error message when a node fails to stop.
+pub const ERR_NODE_UNABLE_TO_STOP: &str = "unable to stop the node";
+
+/// Error message when sending message fails.
+pub const ERR_SEND_MESSAGE_FAILED: &str = "unable to send message";
+
+/// Error message when synthetic node creation fails.
+pub const ERR_SYNTH_NODE_BUILD_FAILED: &str = "unable to build a synthetic node";
+
+/// Error message when temporary directory creation fails.
+pub const ERR_TEMPDIR_CREATION_FAILED: &str = "couldn't create a temporary directory";


### PR DESCRIPTION
This test checks if the node behaves as expected under load when some peers are sending higher priority messages and some other peer is trying to request blocks with certificates (that are lower priority messages).

Test will be refactored in the next PR - message hardcodes will be changed to message factory that will construct messages and payloads to be used during tests.