### PR TITLE
feat: resistance test - send an enormous message

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,4 +81,4 @@ These results were obtained by running the test suite against [Algorand v3.12.2-
 | [001](SPEC.md#ZG-RESISTANCE-001)  |   -    |                                                                             |
 | [002](SPEC.md#ZG-RESISTANCE-002)  |  ✓/✖   | The procedure accepts sometimes invalid requests (should be improved)       |
 | [003](SPEC.md#ZG-RESISTANCE-003)  |   -    |                                                                             |
-| [004](SPEC.md#ZG-RESISTANCE-004)  |   -    |                                                                             |
+| [004](SPEC.md#ZG-RESISTANCE-004)  |   ✓    |                                                                             |

--- a/SPEC.md
+++ b/SPEC.md
@@ -79,23 +79,21 @@ The fuzz tests aim to buttress the message conformance tests with extra verifica
 
 |  Message                   | Type                  | Coverage | Tests                             |
 |----------------------------|-----------------------|----------|-----------------------------------|
-| /v1/{network-name}/gossip  | HTTP (handshake)      | ✅       | `C001`, `C002`, `C003`            |
+| /v1/{network-name}/gossip  | HTTP (handshake)      | ✅       | `C001`, `C002`, `C003`, `R002`    |
 | /v1/block/{round}          | HTTP (get block)      | ✅       | `C004`                            |
 | AgreementVoteTag           | WS data (Tag: AV)     | ✅       | `C008`                            |
-| MsgOfInterestTag           | WS data (Tag: MI)     | ✅       | `C005`, `C006`                    |
+| MsgOfInterestTag           | WS data (Tag: MI)     | ✅       | `C005`, `C006`, `P002`            |
 | MsgDigestSkipTag           | WS data (Tag: MS)     | ❌       |                                   |
 | NetPrioResponseTag         | WS data (Tag: NP)     | ✅       | `C011`                            |
 | PingTag                    | WS data (Tag: pi)     | ✅       | `C009`                            |
 | PingReplyTag               | WS data (Tag: pj)     | ✅       | `C009`                            |
-| ProposalPayloadTag         | WS data (Tag: PP)     | ✅       | `C007`                            |
+| ProposalPayloadTag         | WS data (Tag: PP)     | ✅       | `C007`, `R004`                    |
 | StateProofSigTag           | WS data (Tag: SP)     | ❌       |                                   |
 | UniCatchupReqTag           | WS data (Tag: UC)     | ✅       | `C010`                            |
-| UniEnsBlockReqTag          | WS data (Tag: UE)     | ✅       | `C010`                            |
-| TopicMsgRespTag            | WS data (Tag: TS)     | ✅       | `C010`                            |
+| UniEnsBlockReqTag          | WS data (Tag: UE)     | ✅       | `C010`, `P001`, `P002`            |
+| TopicMsgRespTag            | WS data (Tag: TS)     | ✅       | `C010`, `P001`, `P002`            |
 | TxnTag                     | WS data (Tag: TX)     | ✅       | `C012`                            |
 | VoteBundleTag              | WS data (Tag: VB)     | ❌       |                                   |
-
-_TODO: Investigate more REST API calls and possibly include above._
 
 ## Conformance
 
@@ -262,7 +260,7 @@ _TODO: Investigate more REST API calls and possibly include above._
 
 ### ZG-RESISTANCE-002
 
-    Node rejects the handshake in case the request handshake message contains invalid data.
+    The node rejects the handshake in case the request handshake message contains invalid data.
 
     ->
     -> http handshake request (with an invalid data)
@@ -276,5 +274,12 @@ _TODO: Investigate more REST API calls and possibly include above._
 
 ### ZG-RESISTANCE-004
 
-    Reserved
+    The node can handle enormous messages.
+
+    <>
+    -> ProposalPayload (enormous size)
+
+    Assert: the node handles enormous messages properly.
+
+    TODO(Rqnsom): Add subtest 2 description
 

--- a/src/protocol/reading.rs
+++ b/src/protocol/reading.rs
@@ -4,30 +4,30 @@ use pea2pea::{protocols::Reading, ConnectionSide, Pea2Pea};
 use tracing::*;
 
 use crate::{
-    protocol::codecs::{algomsg::AlgoMsgCodec, payload::Payload},
+    protocol::codecs::algomsg::{AlgoMsg, AlgoMsgCodec},
     tools::inner_node::InnerNode,
 };
 
 #[async_trait::async_trait]
 impl Reading for InnerNode {
-    type Message = Payload;
+    type Message = AlgoMsg;
     type Codec = AlgoMsgCodec;
 
     fn codec(&self, _addr: SocketAddr, _side: ConnectionSide) -> Self::Codec {
         AlgoMsgCodec::new(self.node().span().clone())
     }
 
-    /// Terminates WebSocket packets, decodes and forwards algod message [Payload] to synthetic node's inbound queue.
-    async fn process_message(&self, source: SocketAddr, payload: Self::Message) -> io::Result<()> {
+    /// Terminates WebSocket packets, decodes and forwards [AlgoMsg] message to synthetic node's inbound queue.
+    async fn process_message(&self, source: SocketAddr, msg: Self::Message) -> io::Result<()> {
         let span = self.node().span();
 
-        debug!(parent: span, "got a message from {}", source);
         debug!(
             parent: span,
-            "sending the message to the node's inbound queue: {:?}", payload
+            "sending a message received from {source} to the synthetic node's inbound queue: {:?}",
+            msg.payload
         );
         self.inbound_tx
-            .send((source, payload))
+            .send((source, msg))
             .await
             .expect("receiver dropped");
 

--- a/src/tests/conformance/mod.rs
+++ b/src/tests/conformance/mod.rs
@@ -1,2 +1,2 @@
 mod handshake;
-mod post_handshake;
+pub mod post_handshake;

--- a/src/tests/conformance/post_handshake/cmd/mod.rs
+++ b/src/tests/conformance/post_handshake/cmd/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     tools::synthetic_node::{SyntheticNode, SyntheticNodeBuilder},
 };
 
-async fn get_handshaked_synth_node(net_addr: SocketAddr) -> SyntheticNode {
+pub async fn get_handshaked_synth_node(net_addr: SocketAddr) -> SyntheticNode {
     // Create a synthetic node and enable handshaking.
     let synthetic_node = SyntheticNodeBuilder::default()
         .build()
@@ -32,7 +32,7 @@ async fn get_handshaked_synth_node(net_addr: SocketAddr) -> SyntheticNode {
     synthetic_node
 }
 
-async fn get_wallet_token(kmd: &mut Kmd) -> String {
+pub async fn get_wallet_token(kmd: &mut Kmd) -> String {
     let wallets = kmd.get_wallets().await.expect("couldn't get the wallets");
 
     let wallet_id = wallets
@@ -48,7 +48,7 @@ async fn get_wallet_token(kmd: &mut Kmd) -> String {
         .wallet_handle_token
 }
 
-async fn get_txn_params(node: &mut Node) -> TransactionParams {
+pub async fn get_txn_params(node: &mut Node) -> TransactionParams {
     node.rest_client()
         .expect("couldn't get the REST client")
         .get_transaction_params()
@@ -56,7 +56,7 @@ async fn get_txn_params(node: &mut Node) -> TransactionParams {
         .expect("couldn't get the transaction parameters")
 }
 
-async fn get_pub_key_addr(kmd: &mut Kmd, wallet_token: String) -> Address {
+pub async fn get_pub_key_addr(kmd: &mut Kmd, wallet_token: String) -> Address {
     let pub_key = kmd
         .get_keys(wallet_token)
         .await
@@ -68,7 +68,11 @@ async fn get_pub_key_addr(kmd: &mut Kmd, wallet_token: String) -> Address {
     Address::from_string(&pub_key).expect("couldn't convert public key to address")
 }
 
-async fn get_signed_tagged_txn(kmd: &mut Kmd, wallet_token: String, txn: &Transaction) -> Vec<u8> {
+pub async fn get_signed_tagged_txn(
+    kmd: &mut Kmd,
+    wallet_token: String,
+    txn: &Transaction,
+) -> Vec<u8> {
     let mut signed_txn = kmd
         .sign_transaction(wallet_token, "".to_string(), txn)
         .await

--- a/src/tests/conformance/post_handshake/mod.rs
+++ b/src/tests/conformance/post_handshake/mod.rs
@@ -1,5 +1,5 @@
 mod broadcast;
-mod cmd;
+pub mod cmd;
 mod msg_of_interest;
 mod net_prio_response;
 mod query;

--- a/src/tests/conformance/post_handshake/query/ping.rs
+++ b/src/tests/conformance/post_handshake/query/ping.rs
@@ -2,7 +2,10 @@ use tempfile::TempDir;
 use tokio::time::{timeout, Duration};
 
 use crate::{
-    protocol::codecs::payload::{Payload, PingData},
+    protocol::codecs::{
+        algomsg::AlgoMsg,
+        payload::{Payload, PingData},
+    },
     setup::node::Node,
     tools::synthetic_node::SyntheticNodeBuilder,
 };
@@ -95,8 +98,11 @@ async fn c009_t2_PING_PING_REPLY_wait_for_a_ping_req() {
     // Wait for at least 10 minutes.
     assert!(timeout(Duration::from_secs(610), async {
         loop {
-            match synthetic_node.recv_message().await {
-                (_, Payload::AgreementVote(_) | Payload::ProposalPayload(_)) => continue,
+            match synthetic_node.recv_message().await.1 {
+                AlgoMsg {
+                    payload: Payload::AgreementVote(_) | Payload::ProposalPayload(_),
+                    ..
+                } => continue,
                 msg => {
                     tracing::info!("Received a message: {:?}", msg);
                     return true;

--- a/src/tests/performance/get_blocks.rs
+++ b/src/tests/performance/get_blocks.rs
@@ -9,6 +9,7 @@ use tokio::{net::TcpSocket, task::JoinSet, time::timeout};
 
 use crate::{
     protocol::codecs::{
+        algomsg::AlgoMsg,
         msgpack::Round,
         payload::Payload,
         topic::{TopicMsgResp, UniEnsBlockReq, UniEnsBlockReqType},
@@ -173,7 +174,7 @@ async fn simulate_peer(node_addr: SocketAddr, socket: TcpSocket) {
         timeout(RESPONSE_TIMEOUT, async {
             loop {
                 let m = synth_node.recv_message().await;
-                if matches!(&m.1, Payload::TopicMsgResp(TopicMsgResp::UniEnsBlockRsp(rsp))
+                if matches!(&m.1, AlgoMsg { payload: Payload::TopicMsgResp(TopicMsgResp::UniEnsBlockRsp(rsp)), .. }
                      if rsp.block.is_some() && rsp.block.as_ref().unwrap().round == ROUND_KEY && rsp.cert.is_some()) {
                     metrics::histogram!(METRIC_LATENCY, duration_as_ms(now.elapsed()));
                     break;

--- a/src/tests/performance/prio_test.rs
+++ b/src/tests/performance/prio_test.rs
@@ -13,6 +13,7 @@ use tokio::{net::TcpSocket, sync::Barrier, task::JoinSet, time::timeout};
 
 use crate::{
     protocol::codecs::{
+        algomsg::AlgoMsg,
         msgpack::Round,
         payload::Payload,
         tagmsg::Tag,
@@ -254,8 +255,8 @@ async fn simulate_low_priority_peer(
         // In every other case we simply move out and go to another request iteration.
         timeout(RESPONSE_TIMEOUT, async {
             loop {
-                let m = synth_node.recv_message().await;
-                if matches!(&m.1, Payload::TopicMsgResp(TopicMsgResp::UniEnsBlockRsp(rsp))
+                let m = synth_node.recv_message().await.1;
+                if matches!(&m, AlgoMsg { payload: Payload::TopicMsgResp(TopicMsgResp::UniEnsBlockRsp(rsp)), ..}
                      if rsp.block.is_some() && rsp.block.as_ref().unwrap().round == ROUND_KEY && rsp.cert.is_some()) {
                     metrics::histogram!(METRIC_LATENCY, duration_as_ms(now.elapsed()));
                     break;

--- a/src/tests/resistance/mod.rs
+++ b/src/tests/resistance/mod.rs
@@ -1,1 +1,2 @@
 mod handshake;
+mod post_handshake;

--- a/src/tests/resistance/post_handshake/enormous_message.rs
+++ b/src/tests/resistance/post_handshake/enormous_message.rs
@@ -1,0 +1,154 @@
+use tempfile::TempDir;
+use tokio::time::{sleep, timeout, Duration};
+
+use crate::{
+    protocol::codecs::{
+        algomsg::AlgoMsg,
+        msgpack::{Payment, Transaction, TransactionType},
+        payload::Payload,
+    },
+    setup::{kmd::Kmd, node::Node},
+    tests::conformance::post_handshake::cmd::{
+        get_handshaked_synth_node, get_pub_key_addr, get_signed_tagged_txn, get_txn_params,
+        get_wallet_token,
+    },
+    tools::constants::{
+        ERR_KMD_BUILD, ERR_KMD_STOP, ERR_NODE_ADDR, ERR_NODE_BUILD, ERR_NODE_STOP, ERR_TEMPDIR_NEW,
+        EXPECT_MSG_TIMEOUT,
+    },
+};
+
+// Generates a valid proposal payload message which contains a massive amount of transactions.
+async fn get_huge_proposal_payload() -> AlgoMsg {
+    // Spin up a node instance.
+    let target = TempDir::new().expect(ERR_TEMPDIR_NEW);
+    let mut node = Node::builder().build(target.path()).expect(ERR_NODE_BUILD);
+    node.start().await;
+
+    let mut kmd = Kmd::builder()
+        .build(target.path())
+        .await
+        .expect(ERR_KMD_BUILD);
+    kmd.start().await;
+
+    let wallet_token = get_wallet_token(&mut kmd).await;
+    let txn_params = get_txn_params(&mut node).await;
+
+    let rx_addr = get_pub_key_addr(&mut kmd, wallet_token.clone()).await;
+    let tx_addr = rx_addr;
+
+    const TXN_CNT: u64 = 1000;
+    let mut txns = Vec::with_capacity(TXN_CNT as usize);
+
+    for i in 0..TXN_CNT {
+        let txn_type = TransactionType::Payment(Payment {
+            receiver: rx_addr,
+            amount: 1000 + i,
+            close_remainder_to: None,
+        });
+
+        // Create a huge transaction - use a maximum note length.
+        let txn = Transaction {
+            sender: tx_addr,
+            fee: txn_params.min_fee,
+            first_valid: txn_params.last_round,
+            last_valid: txn_params.last_round + 1000,
+            note: vec![b'y'; 1024],
+            genesis_id: txn_params.genesis_id.clone(),
+            genesis_hash: txn_params.genesis_hash,
+            group: None,
+            lease: None,
+            txn_type,
+            rekey_to: None,
+        };
+
+        txns.push(Payload::RawBytes(
+            get_signed_tagged_txn(&mut kmd, wallet_token.clone(), &txn).await,
+        ));
+    }
+
+    // Transactions are prepared, shut down the kmd instance.
+    kmd.stop().expect(ERR_KMD_STOP);
+
+    // Create a synthetic node.
+    let net_addr = node.net_addr().expect(ERR_NODE_ADDR);
+    let mut synthetic_node = get_handshaked_synth_node(net_addr).await;
+
+    // Dump all transactions to the node which will end up in the next ProposalPayload message.
+    for txn in txns {
+        if synthetic_node.unicast(net_addr, txn).is_err() {
+            // Sometimes the synthetic_node cannot process sending so much data at once, so
+            // a small sleep helps here.
+            sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    let proposal_payload_msg = timeout(EXPECT_MSG_TIMEOUT, async {
+        // Proposal payload message size - empirical value.
+        const PP_MSG_LEN: usize = 1000000;
+
+        loop {
+            let m = synthetic_node.recv_message().await.1;
+            if matches!(&m, AlgoMsg { payload: Payload::ProposalPayload(_), raw } if raw.len() > PP_MSG_LEN) {
+                return m
+            }
+        }
+    }).await.expect("couldn't receive ProposalPayload");
+
+    // Gracefully shut down the nodes.
+    synthetic_node.shut_down().await;
+    node.stop().expect(ERR_NODE_STOP);
+
+    proposal_payload_msg
+}
+
+#[tokio::test]
+#[allow(non_snake_case)]
+async fn r004_t1_PROPOPSAL_PAYLOAD_send_a_huge_valid_msg() {
+    // ZG-RESISTANCE-004
+    //
+    // Send a huge valid proposal payload message to the node and expect to remain connected.
+
+    // Get a huge proposal payload message from the dead node.
+    let pp_msg = get_huge_proposal_payload().await;
+
+    // Spin up a node instance.
+    let target = TempDir::new().expect(ERR_TEMPDIR_NEW);
+    let mut node = Node::builder().build(target.path()).expect(ERR_NODE_BUILD);
+    node.start().await;
+
+    // Create a synthetic node.
+    let net_addr = node.net_addr().expect(ERR_NODE_ADDR);
+    let mut synthetic_node = get_handshaked_synth_node(net_addr).await;
+
+    // Wait for at least one ProposalPayload message.
+    let check_pp_msg = |m: &Payload| matches!(&m, Payload::ProposalPayload(_));
+    assert!(synthetic_node.expect_message(&check_pp_msg).await);
+
+    // Send a massive ProposalPayload message recored previouosly.
+    let msg = Payload::RawBytes(pp_msg.raw);
+    assert!(synthetic_node.unicast(net_addr, msg.clone()).is_ok());
+
+    // Clear the inbound queue.
+    while synthetic_node
+        .recv_message_timeout(Duration::from_millis(10))
+        .await
+        .is_ok()
+    {}
+
+    // Check that we are still receiving ProposalPayload messages.
+    assert!(
+        synthetic_node.expect_message(&check_pp_msg).await,
+        "a proposal payload message is missing"
+    );
+
+    // Gracefully shut down the nodes.
+    synthetic_node.shut_down().await;
+    node.stop().expect(ERR_NODE_STOP);
+}
+
+#[tokio::test]
+#[allow(non_snake_case)]
+async fn r004_t2_XXX_send_a_huge_invalid_msg() {
+    // TODO(Rqnsom): implement
+}

--- a/src/tests/resistance/post_handshake/mod.rs
+++ b/src/tests/resistance/post_handshake/mod.rs
@@ -1,0 +1,1 @@
+mod enormous_message;

--- a/src/tools/constants.rs
+++ b/src/tools/constants.rs
@@ -26,6 +26,12 @@ pub const ERR_NODE_BUILD: &str = "unable to build the node";
 /// Error message when a node fails to stop.
 pub const ERR_NODE_STOP: &str = "unable to stop the node";
 
+/// Error message when building a kmd instance fails.
+pub const ERR_KMD_BUILD: &str = "unable to build the kmd instance";
+
+/// Error message when a kmd instance fails to stop.
+pub const ERR_KMD_STOP: &str = "unable to stop the kmd instance";
+
 /// Error message when sending message fails.
 pub const ERR_SYNTH_UNICAST: &str = "unable to send a message";
 

--- a/src/tools/inner_node.rs
+++ b/src/tools/inner_node.rs
@@ -3,19 +3,19 @@ use std::net::SocketAddr;
 use pea2pea::{Node, Pea2Pea};
 use tokio::sync::mpsc::Sender;
 
-use crate::protocol::{codecs::payload::Payload, handshake::HandshakeCfg};
+use crate::protocol::{codecs::algomsg::AlgoMsg, handshake::HandshakeCfg};
 
 #[derive(Clone)]
 pub struct InnerNode {
     node: Node,
     pub handshake_cfg: HandshakeCfg,
-    pub inbound_tx: Sender<(SocketAddr, Payload)>,
+    pub inbound_tx: Sender<(SocketAddr, AlgoMsg)>,
 }
 
 impl InnerNode {
     pub async fn new(
         node: Node,
-        tx: Sender<(SocketAddr, Payload)>,
+        tx: Sender<(SocketAddr, AlgoMsg)>,
         handshake_cfg: HandshakeCfg,
     ) -> Self {
         Self {


### PR DESCRIPTION
```
feat: resistance test - send an enormous message

r004_t1 test sends an enormous valid message and expects to stay
connected with the node.
```
```
refactor: send also raw msg to the synth node

In certain cases synthetic_node will need to use raw data as well, besides the parsed payload.
```