### PR TITLE
feat: add MsgDigestSkip test

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ These results were obtained by running the test suite against [Algorand v3.12.2-
 | [010](SPEC.md#ZG-CONFORMANCE-010) |  ✓/✖   | Only BlockAndCert request is supported, other type requests are unsupported |
 | [011](SPEC.md#ZG-CONFORMANCE-011) |   ✓    |                                                                             |
 | [012](SPEC.md#ZG-CONFORMANCE-012) |   ✓    |                                                                             |
-| [013](SPEC.md#ZG-CONFORMANCE-013) |   -    |                                                                             |
+| [013](SPEC.md#ZG-CONFORMANCE-013) |   ✓    |                                                                             |
 
 ### Performance
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -83,11 +83,11 @@ The fuzz tests aim to buttress the message conformance tests with extra verifica
 | /v1/block/{round}          | HTTP (get block)      | ✅       | `C004`                            |
 | AgreementVoteTag           | WS data (Tag: AV)     | ✅       | `C008`                            |
 | MsgOfInterestTag           | WS data (Tag: MI)     | ✅       | `C005`, `C006`, `P002`            |
-| MsgDigestSkipTag           | WS data (Tag: MS)     | ❌       |                                   |
+| MsgDigestSkipTag           | WS data (Tag: MS)     | ✅       | `C013`                            |
 | NetPrioResponseTag         | WS data (Tag: NP)     | ✅       | `C011`                            |
 | PingTag                    | WS data (Tag: pi)     | ✅       | `C009`                            |
 | PingReplyTag               | WS data (Tag: pj)     | ✅       | `C009`                            |
-| ProposalPayloadTag         | WS data (Tag: PP)     | ✅       | `C007`, `R004`                    |
+| ProposalPayloadTag         | WS data (Tag: PP)     | ✅       | `C007`, `C013`, `R004`            |
 | StateProofSigTag           | WS data (Tag: SP)     | ❌       |                                   |
 | UniCatchupReqTag           | WS data (Tag: UC)     | ✅       | `C010`                            |
 | UniEnsBlockReqTag          | WS data (Tag: UE)     | ✅       | `C010`, `P001`, `P002`            |
@@ -214,11 +214,14 @@ The fuzz tests aim to buttress the message conformance tests with extra verifica
 
 ### ZG-CONFORMANCE-013
 
-    Reserved
+    Send a huge valid proposal payload message to the node from one synthetic node and expect to receive a
+    MsgDigestSkip message on the other synthetic node as a filter for a massive proposal payload message.
 
-### ZG-CONFORMANCE-014
+    <>
+    -> ProposalPayload (enormous size)
+    << MsgDigestSkip (hash of enormous proposal payload)
 
-    Reserved
+    Assert: the node successfully broadcasts the filter message.
 
 ## Performance
 

--- a/src/tests/conformance/post_handshake/cmd/mod.rs
+++ b/src/tests/conformance/post_handshake/cmd/mod.rs
@@ -1,5 +1,6 @@
 //! Test suite for command messages - which do not generate a response from the node.
 
+mod msg_digest_skip;
 mod transaction;
 
 use std::net::SocketAddr;

--- a/src/tests/conformance/post_handshake/cmd/msg_digest_skip.rs
+++ b/src/tests/conformance/post_handshake/cmd/msg_digest_skip.rs
@@ -1,0 +1,67 @@
+use tempfile::TempDir;
+use tokio::time::timeout;
+
+use crate::{
+    protocol::codecs::{algomsg::AlgoMsg, msgpack::HashDigest, payload::Payload},
+    setup::node::Node,
+    tests::{
+        conformance::post_handshake::cmd::get_handshaked_synth_node,
+        resistance::post_handshake::enormous_message::get_huge_proposal_payload,
+    },
+    tools::constants::{
+        ERR_NODE_ADDR, ERR_NODE_BUILD, ERR_NODE_STOP, ERR_TEMPDIR_NEW, EXPECT_MSG_TIMEOUT,
+    },
+};
+
+#[tokio::test]
+#[allow(non_snake_case)]
+async fn c013_t1_MSG_DIGEST_SKIP_receive_a_msg() {
+    // ZG-CONFORMANCE-013
+    //
+    // Send a huge valid proposal payload message to the node from one synthetic node
+    // and expect to receive a MsgDigestSkip message on the other synthetic node.
+
+    // Get a huge proposal payload message from the dead node.
+    let tx_pp_msg = get_huge_proposal_payload().await;
+    let tx_msg_hash = HashDigest::from(&tx_pp_msg.raw);
+
+    // Spin up a node instance.
+    let target = TempDir::new().expect(ERR_TEMPDIR_NEW);
+    let mut node = Node::builder().build(target.path()).expect(ERR_NODE_BUILD);
+    node.start().await;
+
+    // Create synthetic nodes.
+    let net_addr = node.net_addr().expect(ERR_NODE_ADDR);
+    let mut synthetic_node_rx = get_handshaked_synth_node(net_addr).await;
+    let synthetic_node_tx = get_handshaked_synth_node(net_addr).await;
+
+    // Send a massive ProposalPayload message recorded previously.
+    let msg = Payload::RawBytes(tx_pp_msg.raw);
+    assert!(synthetic_node_tx.unicast(net_addr, msg.clone()).is_ok());
+
+    // For messages bigger than 5000 bytes, the node broadcasts a filter message (MsgDigestSkip) to everyone else.
+    let rx_msg_hash = timeout(EXPECT_MSG_TIMEOUT, async {
+        loop {
+            if let AlgoMsg {
+                payload: Payload::MsgDigestSkip(hash),
+                ..
+            } = synthetic_node_rx.recv_message().await.1
+            {
+                return hash;
+            }
+        }
+    })
+    .await
+    .expect("couldn't receive a MsgDigestSkip message");
+
+    // Pre-calculated tx message hash should be the same as the rx message hash received in the MsgDigestSkip message.
+    assert_eq!(
+        rx_msg_hash, tx_msg_hash,
+        "received MsgDigestSkip hash is invalid"
+    );
+
+    // Gracefully shut down the nodes.
+    synthetic_node_rx.shut_down().await;
+    synthetic_node_tx.shut_down().await;
+    node.stop().expect(ERR_NODE_STOP);
+}

--- a/src/tests/resistance/mod.rs
+++ b/src/tests/resistance/mod.rs
@@ -1,2 +1,2 @@
 mod handshake;
-mod post_handshake;
+pub mod post_handshake;

--- a/src/tests/resistance/post_handshake/enormous_message.rs
+++ b/src/tests/resistance/post_handshake/enormous_message.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 // Generates a valid proposal payload message which contains a massive amount of transactions.
-async fn get_huge_proposal_payload() -> AlgoMsg {
+pub async fn get_huge_proposal_payload() -> AlgoMsg {
     // Spin up a node instance.
     let target = TempDir::new().expect(ERR_TEMPDIR_NEW);
     let mut node = Node::builder().build(target.path()).expect(ERR_NODE_BUILD);
@@ -125,7 +125,7 @@ async fn r004_t1_PROPOPSAL_PAYLOAD_send_a_huge_valid_msg() {
     let check_pp_msg = |m: &Payload| matches!(&m, Payload::ProposalPayload(_));
     assert!(synthetic_node.expect_message(&check_pp_msg).await);
 
-    // Send a massive ProposalPayload message recored previouosly.
+    // Send a massive ProposalPayload message recorded previously.
     let msg = Payload::RawBytes(pp_msg.raw);
     assert!(synthetic_node.unicast(net_addr, msg.clone()).is_ok());
 

--- a/src/tests/resistance/post_handshake/mod.rs
+++ b/src/tests/resistance/post_handshake/mod.rs
@@ -1,1 +1,1 @@
-mod enormous_message;
+pub mod enormous_message;


### PR DESCRIPTION
Send a huge valid proposal payload message to the node from one synthetic node and expect to recieve a MsgDigestSkip message on the other synthetic node.