### PR TITLE
refactor: prio tests changed to be generic traffic tests

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -244,7 +244,7 @@ The fuzz tests aim to buttress the message conformance tests with extra verifica
     Normal peer (example):
     <>
     In loop:
-        -> UniEnsBlockReq 
+        -> UniEnsBlockReq
         <- TopicMsgResp
 
     High traffic peers (example):

--- a/SPEC.md
+++ b/SPEC.md
@@ -236,21 +236,23 @@ The fuzz tests aim to buttress the message conformance tests with extra verifica
 
 ### ZG-PERFORMANCE-002
 
-    The node behaves as expected under load when some peers are sending higher priority messages and some other peer 
-    is trying to request blocks with certificates (that are lower priority messages).
+    The node behaves as expected under load when some peers are sending much traffic and some other peer 
+    is trying to perform some other operations. There are different test cases checked especially the ones when
+    nodes are sending traffic with messages with different priorities as well as the ones when nodes are sending
+    messages with the same priority.
 
-    Normal peer:
+    Normal peer (example):
     <>
     In loop:
-        -> UniEnsBlockReq
+        -> UniEnsBlockReq 
         <- TopicMsgResp
 
-    High priority peers (potential malicious ones):
+    High traffic peers (example):
         <>
     In loop:
         -> MsgOfInterest
 
-    Results should be introspected manually to check the normal peer responsiveness (latency, throughput) when requesting block data.
+    Results should be introspected manually to check the normal peer responsiveness (latency, throughput) when performing its operations.
 
 ## Resistance
 

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -3,6 +3,8 @@
 pub mod codecs;
 pub mod constants;
 pub mod handshake;
+#[allow(dead_code)]
+pub mod payload_factory;
 mod reading;
 mod writing;
 

--- a/src/protocol/payload_factory.rs
+++ b/src/protocol/payload_factory.rs
@@ -8,10 +8,8 @@ pub struct PayloadFactory {
 
 impl PayloadFactory {
     /// Create a new payload factory using specified payload as a template.
-    pub fn new(payload_type: Payload) -> Self {
-        Self {
-            payload: payload_type,
-        }
+    pub fn new(payload: Payload) -> Self {
+        Self { payload }
     }
 
     // TODO[asmie]: Add generate() method to start generating payloads (first message).
@@ -19,17 +17,16 @@ impl PayloadFactory {
 
     /// Create a new payload with the same type as the template. If there is a need to
     /// change any payload fields it's done here.
-    pub fn generate_next(&self) -> Payload {
-        let msg = self.payload.clone();
-
+    pub fn generate_next(&mut self) -> Payload {
         // For now, we're incrementing nonce in UniEnsBlockReq and not change other
         // type of messages.
-        match msg {
-            Payload::UniEnsBlockReq(mut message) => {
+        match &mut self.payload {
+            Payload::UniEnsBlockReq(message) => {
                 message.nonce += 1;
-                Payload::UniEnsBlockReq(message)
             }
-            _ => msg,
-        }
+            _ => {}
+        };
+
+        self.payload.clone()
     }
 }

--- a/src/protocol/payload_factory.rs
+++ b/src/protocol/payload_factory.rs
@@ -20,12 +20,9 @@ impl PayloadFactory {
     pub fn generate_next(&mut self) -> Payload {
         // For now, we're incrementing nonce in UniEnsBlockReq and not change other
         // type of messages.
-        match &mut self.payload {
-            Payload::UniEnsBlockReq(message) => {
-                message.nonce += 1;
-            }
-            _ => {}
-        };
+        if let Payload::UniEnsBlockReq(message) = &mut self.payload {
+            message.nonce += 1;
+        }
 
         self.payload.clone()
     }

--- a/src/protocol/payload_factory.rs
+++ b/src/protocol/payload_factory.rs
@@ -1,0 +1,35 @@
+use crate::protocol::codecs::payload::Payload;
+
+/// A factory for creating payloads.
+#[derive(Clone)]
+pub struct PayloadFactory {
+    payload: Payload,
+}
+
+impl PayloadFactory {
+    /// Create a new payload factory using specified payload as a template.
+    pub fn new(payload_type: Payload) -> Self {
+        Self {
+            payload: payload_type,
+        }
+    }
+
+    // TODO[asmie]: Add generate() method to start generating payloads (first message).
+    // TODO[asmie]: Re-think API of the PayloadFactory to handle all generic cases (like creating custom payloads with custom fields).
+
+    /// Create a new payload with the same type as the template. If there is a need to
+    /// change any payload fields it's done here.
+    pub fn generate_next(&self) -> Payload {
+        let msg = self.payload.clone();
+
+        // For now, we're incrementing nonce in UniEnsBlockReq and not change other
+        // type of messages.
+        match msg {
+            Payload::UniEnsBlockReq(mut message) => {
+                message.nonce += 1;
+                Payload::UniEnsBlockReq(message)
+            }
+            _ => msg,
+        }
+    }
+}

--- a/src/tests/performance/prio_test.rs
+++ b/src/tests/performance/prio_test.rs
@@ -67,14 +67,14 @@ pub struct RequestStats {
 impl RequestStats {
     pub fn new(
         normal_peers: u16,
-        traffic_peers: u16,
+        high_traffic_peers: u16,
         requests: u16,
         latency: Histogram,
         time: f64,
     ) -> Self {
         Self {
             normal_peers,
-            high_traffic_peers: traffic_peers,
+            high_traffic_peers,
             requests,
             completion: (latency.entries() as f64) / (normal_peers as f64 * requests as f64)
                 * 100.00,
@@ -271,7 +271,7 @@ async fn simulate_normal_traffic_peer(
     node_addr: SocketAddr,
     socket: TcpSocket,
     start_barrier: Arc<Barrier>,
-    normal_traffic_factory: PayloadFactory,
+    mut normal_traffic_factory: PayloadFactory,
 ) {
     let mut synth_node = SyntheticNodeBuilder::default()
         .build()
@@ -326,7 +326,7 @@ async fn simulate_high_priority_peer(
     node_addr: SocketAddr,
     socket: TcpSocket,
     start_barrier: Arc<Barrier>,
-    high_traffic_factory: PayloadFactory,
+    mut high_traffic_factory: PayloadFactory,
 ) {
     let mut synth_node = SyntheticNodeBuilder::default()
         .build()


### PR DESCRIPTION
Two types of peers can be defined now: normal peers which generate and receive some traffic that is measured and high traffic peers which try to flood the node with some other traffic.

Some of the conecpts need to be extended - factory should contain also first message generation (as well as custom message with some custom values) and each payload type should contain matcher associated with it.