### PR TITLE
refactor: add override_timeout arg to expect_msg

### DIFF
--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use tempfile::TempDir;
 use tokio::time::timeout;
 
@@ -89,6 +91,8 @@ async fn c002_handshake_when_node_initiates_connection() {
     node.stop().expect("unable to stop the node");
 }
 
+const NO_MSG_TIMEOUT: Option<Duration> = Some(Duration::from_secs(5));
+
 #[tokio::test]
 async fn c003_t1_expect_no_messages_before_handshake() {
     // ZG-CONFORMANCE-003
@@ -119,7 +123,11 @@ async fn c003_t1_expect_no_messages_before_handshake() {
         .expect("unable to connect");
 
     let expect_any_msg = |_: &Payload| true;
-    assert!(!synthetic_node.expect_message(&expect_any_msg).await);
+    assert!(
+        !synthetic_node
+            .expect_message(&expect_any_msg, NO_MSG_TIMEOUT)
+            .await
+    );
 
     // Gracefully shut down the nodes.
     synthetic_node.shut_down().await;
@@ -156,7 +164,11 @@ async fn c003_t2_expect_no_messages_before_handshake() {
     node.start().await;
 
     let expect_any_msg = |_: &Payload| true;
-    assert!(!synthetic_node.expect_message(&expect_any_msg).await);
+    assert!(
+        !synthetic_node
+            .expect_message(&expect_any_msg, NO_MSG_TIMEOUT)
+            .await
+    );
 
     // Gracefully shut down the nodes.
     synthetic_node.shut_down().await;

--- a/src/tests/conformance/post_handshake/broadcast/agreementvote.rs
+++ b/src/tests/conformance/post_handshake/broadcast/agreementvote.rs
@@ -35,7 +35,7 @@ async fn c008_AGREEMENT_VOTE_expect_after_connect() {
 
     // Wait for two messages at least.
     for _ in 0..2 {
-        assert!(synthetic_node.expect_message(&check).await);
+        assert!(synthetic_node.expect_message(&check, None).await);
     }
 
     // Gracefully shut down the nodes.

--- a/src/tests/conformance/post_handshake/broadcast/proposalpayload.rs
+++ b/src/tests/conformance/post_handshake/broadcast/proposalpayload.rs
@@ -35,7 +35,7 @@ async fn c007_PROPOSAL_PAYLOAD_expect_after_connect() {
 
     // Wait for two messages at least.
     for _ in 0..2 {
-        assert!(synthetic_node.expect_message(&check).await);
+        assert!(synthetic_node.expect_message(&check, None).await);
     }
 
     // Gracefully shut down the nodes.

--- a/src/tests/conformance/post_handshake/cmd/transaction.rs
+++ b/src/tests/conformance/post_handshake/cmd/transaction.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use tempfile::TempDir;
 
 use crate::{
@@ -74,7 +76,9 @@ async fn c012_TXN_submit_txn_and_expect_to_receive_it() {
 
     let check = |m: &Payload| matches!(&m, Payload::Transaction(_));
     assert!(
-        synthetic_node_rx.expect_message(&check).await,
+        synthetic_node_rx
+            .expect_message(&check, Some(Duration::from_secs(3)))
+            .await,
         "a broadcasted transaction is missing"
     );
 

--- a/src/tests/conformance/post_handshake/net_prio_response.rs
+++ b/src/tests/conformance/post_handshake/net_prio_response.rs
@@ -1,5 +1,6 @@
 use data_encoding::BASE64;
 use tempfile::TempDir;
+use tokio::time::Duration;
 
 use crate::{
     protocol::{
@@ -12,6 +13,8 @@ use crate::{
     setup::node::Node,
     tools::synthetic_node::SyntheticNodeBuilder,
 };
+
+const MSG_TIMEOUT: Option<Duration> = Some(Duration::from_secs(3));
 
 #[tokio::test]
 #[allow(non_snake_case)]
@@ -50,7 +53,7 @@ async fn c011_t1_NET_PRIO_RESPONSE_expect_rsp_from_the_node() {
         matches!(&m, Payload::NetPrioResponse(NetPrioResponse{response: Response { nonce }, ..})
                  if *nonce == challenge)
     };
-    assert!(synthetic_node.expect_message(&check).await);
+    assert!(synthetic_node.expect_message(&check, MSG_TIMEOUT).await);
 
     // Gracefully shut down the nodes.
     synthetic_node.shut_down().await;
@@ -85,7 +88,7 @@ async fn c011_t2_NET_PRIO_RESPONSE_no_rsp_if_challenge_not_sent() {
     node.start().await;
 
     let check = |m: &Payload| matches!(&m, Payload::NetPrioResponse(..));
-    assert!(!synthetic_node.expect_message(&check).await);
+    assert!(!synthetic_node.expect_message(&check, MSG_TIMEOUT).await);
 
     // Gracefully shut down the nodes.
     synthetic_node.shut_down().await;

--- a/src/tests/conformance/post_handshake/query/get_block.rs
+++ b/src/tests/conformance/post_handshake/query/get_block.rs
@@ -108,7 +108,7 @@ async fn c010_t1_UNI_ENS_BLOCK_REQ_get_block_and_cert() {
                      if rsp.block.is_some() && rsp.block.as_ref().unwrap().round == round && rsp.cert.is_some())
         };
         assert!(
-            synthetic_node.expect_message(&check).await,
+            synthetic_node.expect_message(&check, None).await,
             "the UniEnsBlockRsp response is missing"
         );
     }
@@ -165,7 +165,7 @@ async fn c010_t2_UNI_ENS_BLOCK_REQ_get_block_only() {
                      if rsp.error.as_str() == "requested data type is unsupported")
         };
         assert!(
-            synthetic_node.expect_message(&check).await,
+            synthetic_node.expect_message(&check, None).await,
             "the UniEnsBlockRsp response is missing"
         );
     }
@@ -222,7 +222,7 @@ async fn c010_t3_UNI_ENS_BLOCK_REQ_get_cert_only() {
                      if rsp.error.as_str() == "requested data type is unsupported")
         };
         assert!(
-            synthetic_node.expect_message(&check).await,
+            synthetic_node.expect_message(&check, None).await,
             "the UniEnsBlockRsp response is missing"
         );
     }
@@ -270,7 +270,7 @@ async fn c010_t4_UNI_ENS_BLOCK_REQ_cannot_get_non_existent_block() {
                  if rsp.error.as_str() == "requested block is not available")
     };
     assert!(
-        synthetic_node.expect_message(&check).await,
+        synthetic_node.expect_message(&check, None).await,
         "the UniEnsBlockRsp response is missing"
     );
 
@@ -324,7 +324,7 @@ async fn c010_t5_UNI_CATCHUP_REQ_get_block_all_variations() {
                      if rsp.block.is_some() && rsp.block.as_ref().unwrap().round == round && rsp.cert.is_some())
         };
         assert!(
-            synthetic_node.expect_message(&check).await,
+            synthetic_node.expect_message(&check, None).await,
             "the UniEnsBlockRsp response is missing"
         );
     }
@@ -344,7 +344,7 @@ async fn c010_t5_UNI_CATCHUP_REQ_get_block_all_variations() {
                      if rsp.error.as_str() == "requested data type is unsupported")
         };
         assert!(
-            synthetic_node.expect_message(&check).await,
+            synthetic_node.expect_message(&check, None).await,
             "the UniEnsBlockRsp response is missing"
         );
     }
@@ -364,7 +364,7 @@ async fn c010_t5_UNI_CATCHUP_REQ_get_block_all_variations() {
                      if rsp.error.as_str() == "requested data type is unsupported")
         };
         assert!(
-            synthetic_node.expect_message(&check).await,
+            synthetic_node.expect_message(&check, None).await,
             "the UniEnsBlockRsp response is missing"
         );
     }
@@ -383,7 +383,7 @@ async fn c010_t5_UNI_CATCHUP_REQ_get_block_all_variations() {
                      if rsp.error.as_str() == "requested block is not available")
         };
         assert!(
-            synthetic_node.expect_message(&check).await,
+            synthetic_node.expect_message(&check, None).await,
             "the UniEnsBlockRsp response is missing"
         );
     }

--- a/src/tests/conformance/post_handshake/query/ping.rs
+++ b/src/tests/conformance/post_handshake/query/ping.rs
@@ -44,8 +44,9 @@ async fn c009_t1_PING_PING_REPLY_send_req_expect_reply() {
     // Expect a PingReply response with the same data.
     let check =
         |m: &Payload| matches!(&m, Payload::PingReply(PingData{nonce: data}) if *data == nonce);
+    let duration = Some(Duration::from_secs(3));
     assert!(
-        synthetic_node.expect_message(&check).await,
+        synthetic_node.expect_message(&check, duration).await,
         "the PingReply response is missing"
     );
 
@@ -94,7 +95,7 @@ async fn c009_t2_PING_PING_REPLY_wait_for_a_ping_req() {
     // Alternative approach at the moment: wait for any non-broadcast message:
     // Filter out the MsgOfInterest message.
     let check = |m: &Payload| matches!(&m, Payload::MsgOfInterest(..));
-    assert!(synthetic_node.expect_message(&check).await);
+    assert!(synthetic_node.expect_message(&check, None).await);
     // Wait for at least 10 minutes.
     assert!(timeout(Duration::from_secs(610), async {
         loop {

--- a/src/tests/resistance/handshake.rs
+++ b/src/tests/resistance/handshake.rs
@@ -39,7 +39,7 @@ async fn run_handshake_req_test_with_cfg(cfg: HandshakeCfg, debug: bool) -> bool
     } else {
         // Wait for any message.
         synthetic_node
-            .expect_message(&|m: &Payload| matches!(&m, _))
+            .expect_message(&|m: &Payload| matches!(&m, _), None)
             .await
     };
 

--- a/src/tests/resistance/post_handshake/enormous_message.rs
+++ b/src/tests/resistance/post_handshake/enormous_message.rs
@@ -124,7 +124,7 @@ async fn r004_t1_PROPOPSAL_PAYLOAD_send_a_huge_valid_msg() {
 
     // Wait for at least one ProposalPayload message.
     let check_pp_msg = |m: &Payload| matches!(&m, Payload::ProposalPayload(_));
-    assert!(synthetic_node.expect_message(&check_pp_msg).await);
+    assert!(synthetic_node.expect_message(&check_pp_msg, None).await);
 
     // Send a massive ProposalPayload message recorded previously.
     let msg = Payload::RawBytes(pp_msg.raw);
@@ -139,7 +139,7 @@ async fn r004_t1_PROPOPSAL_PAYLOAD_send_a_huge_valid_msg() {
 
     // Check that we are still receiving ProposalPayload messages.
     assert!(
-        synthetic_node.expect_message(&check_pp_msg).await,
+        synthetic_node.expect_message(&check_pp_msg, None).await,
         "a proposal payload message is missing"
     );
 
@@ -184,7 +184,7 @@ async fn r004_t2_MSG_DIGEST_SKIP_send_a_huge_invalid_msg() {
     // Check that we are still receiving messages.
     assert!(
         !synthetic_node
-            .expect_message(&|m: &Payload| matches!(&m, _))
+            .expect_message(&|m: &Payload| matches!(&m, _), None)
             .await,
         "the connection is still established"
     );

--- a/src/tools/synthetic_node.rs
+++ b/src/tools/synthetic_node.rs
@@ -193,8 +193,14 @@ impl SyntheticNode {
     }
 
     /// Expects a message.
-    pub async fn expect_message(&mut self, check: &dyn Fn(&Payload) -> bool) -> bool {
-        timeout(EXPECT_MSG_TIMEOUT, async {
+    pub async fn expect_message(
+        &mut self,
+        check: &dyn Fn(&Payload) -> bool,
+        override_timeout: Option<Duration>,
+    ) -> bool {
+        let duration = override_timeout.unwrap_or(EXPECT_MSG_TIMEOUT);
+
+        timeout(duration, async {
             loop {
                 let (_, msg) = self.recv_message().await;
                 if check(&msg.payload) {


### PR DESCRIPTION
- user should be allowed to override the default timeout value for the expect_message function in the synthetic_node - to make overall test execution shorter