### PR TITLE
chore: update description for ignored tests

### DIFF
--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -134,8 +134,9 @@ async fn c003_t1_expect_no_messages_before_handshake() {
     node.stop().expect("unable to stop the node");
 }
 
-// TODO(Rqnsom): Maybe this test makes no sense because we do get bombarded with the GET_BLOCK requests,
+// NOTE: Maybe this test makes no sense because we do get bombarded with the GET_BLOCK requests,
 // but our Reading thread still doesn't know how to parse those so we get a pea2pea invalid data error.
+// Conclusion: We'll keep the test - to be used for future testing.
 #[tokio::test]
 async fn c003_t2_expect_no_messages_before_handshake() {
     // ZG-CONFORMANCE-003

--- a/src/tests/conformance/post_handshake/query/ping.rs
+++ b/src/tests/conformance/post_handshake/query/ping.rs
@@ -57,7 +57,7 @@ async fn c009_t1_PING_PING_REPLY_send_req_expect_reply() {
 
 #[tokio::test]
 #[allow(non_snake_case)]
-#[ignore]
+#[ignore = "a very long test"]
 async fn c009_t2_PING_PING_REPLY_wait_for_a_ping_req() {
     // ZG-CONFORMANCE-009
 

--- a/src/tests/performance/get_blocks.rs
+++ b/src/tests/performance/get_blocks.rs
@@ -38,7 +38,10 @@ const METRIC_LATENCY: &str = "block_test_latency";
 const REQUESTS: u16 = 100;
 const RESPONSE_TIMEOUT: Duration = Duration::from_secs(3);
 
-#[cfg_attr(not(feature = "performance"), ignore)]
+#[cfg_attr(
+    not(feature = "performance"),
+    ignore = "run this test with the 'performance' feature enabled"
+)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[allow(non_snake_case)]
 async fn p001_GET_BLOCKS_latency() {

--- a/src/tests/performance/prio_test.rs
+++ b/src/tests/performance/prio_test.rs
@@ -133,7 +133,10 @@ const ROUND_KEY: Round = 1;
 // *NOTE* run with `cargo test --release  tests::performance::prio -- --nocapture --test-threads=1`
 // Before running test generate dummy devices with different ips using toos/ips.py
 
-#[cfg_attr(not(feature = "performance"), ignore)]
+#[cfg_attr(
+    not(feature = "performance"),
+    ignore = "run this test with the 'performance' feature enabled"
+)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[allow(non_snake_case)]
 async fn p002_t1_TRAFFIC_HIGH_LOW_latency() {
@@ -167,7 +170,10 @@ async fn p002_t1_TRAFFIC_HIGH_LOW_latency() {
     run_traffic_test(high_prio_factory, low_prio_factory).await;
 }
 
-#[cfg_attr(not(feature = "performance"), ignore)]
+#[cfg_attr(
+    not(feature = "performance"),
+    ignore = "run this test with the 'performance' feature enabled"
+)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[allow(non_snake_case)]
 async fn p002_t2_TRAFFIC_SAME_PRIO_latency() {
@@ -192,7 +198,10 @@ async fn p002_t2_TRAFFIC_SAME_PRIO_latency() {
     run_traffic_test(high_traffic_factory, normal_traffic_factory).await;
 }
 
-#[cfg_attr(not(feature = "performance"), ignore)]
+#[cfg_attr(
+    not(feature = "performance"),
+    ignore = "run this test with the 'performance' feature enabled"
+)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[allow(non_snake_case)]
 async fn p002_t3_COMB_MSG_DIGEST_latency() {

--- a/src/tests/resistance/handshake.rs
+++ b/src/tests/resistance/handshake.rs
@@ -54,7 +54,7 @@ async fn run_handshake_req_test_with_cfg(cfg: HandshakeCfg, debug: bool) -> bool
 }
 
 #[tokio::test]
-#[ignore]
+#[ignore = "internal test"]
 async fn normal_handshake() {
     // Basically, a copy of the C001 test.
     assert!(

--- a/src/tools/metrics/recorder.rs
+++ b/src/tools/metrics/recorder.rs
@@ -125,13 +125,13 @@ mod tests {
     const HISTOGRAM_SIZE: usize = 50;
 
     #[test]
-    #[ignore]
+    #[ignore = "internal test"]
     fn can_initialize_metrics() {
         let _ = TestMetrics::default();
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "internal test"]
     fn can_get_counter_value() {
         let metrics = TestMetrics::default();
         let counter = register_counter!(METRIC_NAME);
@@ -144,7 +144,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "internal test"]
     fn can_get_gauge_value() {
         let metrics = TestMetrics::default();
         let gauge = register_gauge!(METRIC_NAME);
@@ -159,7 +159,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "internal test"]
     fn can_get_histogram_values() {
         let metrics = TestMetrics::default();
         let histogram = register_histogram!(METRIC_NAME);
@@ -176,7 +176,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "internal test"]
     fn can_construct_histogram() {
         let metrics = TestMetrics::default();
         let histogram = register_histogram!(METRIC_NAME);
@@ -195,7 +195,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "internal test"]
     fn can_construct_multiple_histograms() {
         let metrics = TestMetrics::default();
         let histogram = register_histogram!(METRIC_NAME);


### PR DESCRIPTION
The only actual diff in [tests/performance/get_blocks.rs](https://github.com/runziggurat/algorand/pull/70/files#diff-78b65b6769d31e70406b04b3d4d9def2f35c4792a8aff98201c1bab7c707e9c1) is:

```
#[cfg_attr(
    not(feature = "performance"),
    ignore = "run this test with the 'performance' feature enabled"
)]
```

Why is git doing this... 🤔