### PR TITLE
chore: add deps.rs badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Ziggurat x Algorand
+[![dependency status](https://deps.rs/repo/github/runziggurat/algorand/status.svg)](https://deps.rs/repo/github/runziggurat/algorand)
 
 The Ziggurat implementation for Algorand's `algod` nodes.
 


### PR DESCRIPTION
This PR addresses the Improvement Bucket Task: `Add deps.rs badges to all our readme documents`